### PR TITLE
fix: pass 'permission' to train action

### DIFF
--- a/taskcluster/translations_taskgraph/actions/train.py
+++ b/taskcluster/translations_taskgraph/actions/train.py
@@ -64,6 +64,7 @@ def validate_pretrained_models(params):
     symbol="train",
     description="Initiate part or all of the training pipeline",
     cb_name="train",
+    permission="train",
     order=500,
     context=[],
     available=can_train,


### PR DESCRIPTION
This is required for non-generic actions as of 11.0. I mucked this up when I did the upgrade. (See https://taskcluster-taskgraph.readthedocs.io/en/latest/reference/migrations.html.)