### PR TITLE
Rename docker tags following repository rename

### DIFF
--- a/utils/tasks/docker-build.sh
+++ b/utils/tasks/docker-build.sh
@@ -7,14 +7,14 @@ source utils/tasks/docker-setup.sh
 
 docker build \
   --file taskcluster/docker/base/Dockerfile \
-  --tag ftt-base .
+  --tag translations-base .
 
 docker build \
-  --build-arg DOCKER_IMAGE_PARENT=ftt-base \
+  --build-arg DOCKER_IMAGE_PARENT=translations-base \
   --file taskcluster/docker/test/Dockerfile \
-  --tag ftt-test .
+  --tag translations-test .
 
 docker build \
-  --build-arg DOCKER_IMAGE_PARENT=ftt-test \
+  --build-arg DOCKER_IMAGE_PARENT=translations-test \
   --file docker/Dockerfile \
-  --tag ftt-local .
+  --tag translations-local .

--- a/utils/tasks/docker-run.py
+++ b/utils/tasks/docker-run.py
@@ -43,7 +43,7 @@ def main():
             docker_command.extend(["--volume", volume])
 
     # Specify the Docker image
-    docker_command.append("ftt-local")
+    docker_command.append("translations-local")
 
     # Append any additional args
     if args.other_args:


### PR DESCRIPTION
Our docker tags are labled "ftt" for the previous
repository name "firefox-translations-training".

This patch renames instances of "ftt" to "translations" since the initialism no longer has meaning to new contributors.