### PR TITLE
Add better support for reporting training continuation values

### DIFF
--- a/docs/using-pretrained-models.md
+++ b/docs/using-pretrained-models.md
@@ -19,7 +19,8 @@ experiment:
     # Continue training a teacher model.
     train-teacher:
       urls:
-        - https://firefox-ci-tc.services.mozilla.com/api/queue/v1/task/task-id/artifacts/public/build
+        # Replace the following {task_id} with the "train-teacher" task id.
+        - https://firefox-ci-tc.services.mozilla.com/api/queue/v1/task/{task_id}/artifacts/public/build
       mode: continue
       type: default
 

--- a/utils/trigger_training.py
+++ b/utils/trigger_training.py
@@ -8,6 +8,7 @@ For example:
 
 import argparse
 import datetime
+import json
 from pathlib import Path
 import subprocess
 import sys
@@ -167,13 +168,19 @@ def log_config_info(config_path: Path, config: dict):
     pretrained_models: Optional[dict] = experiment.get("pretrained-models")
     if pretrained_models:
         for key, value in pretrained_models.items():
-            config_details.append((key, value))
+            config_details.append((key, json.dumps(value, indent=2)))
 
     key_len = 0
     for key, _ in config_details:
         key_len = max(key_len, len(key))
 
     for key, value in config_details:
+        if "\n" in value:
+            # Nicely indent any multiline value.
+            padding = " " * (key_len + 6)
+            lines = [padding + n for n in value.split("\n")]
+            value = "\n".join(lines).strip()  # noqa: PLW2901
+
         print(f"{key.rjust(key_len + 4, ' ')}: {value}")
 
 


### PR DESCRIPTION
This makes the step to kick off training a bit nicer for training continuation. Previously it was one line and hard to read.

```
       experiment.name: decoder-tiny
        experiment.src: en
        experiment.trg: lt
           start-stage: train-student
          target-stage: all-pipeline
    previous_group_ids: ['YxrSV7eHR62FHcMmWmsZ6w', 'LtiIriAwSpeT1-GCYqd9Iw', 'e6HrD2nFT8S-Hckt18pxlQ', 'WDNdtYFhTG6gh7c1wnAEyw']
         train-teacher: {
                          "urls": [
                            "https://firefox-ci-tc.services.mozilla.com/api/queue/v1/task/FmL_NEMqQ9qHVZd9tdvbfw/artifacts/public/build/",
                            "https://firefox-ci-tc.services.mozilla.com/api/queue/v1/task/biiW0pGaQ_uWBw-1GLwDgA/artifacts/public/build/"
                          ],
                          "mode": "use",
                          "type": "default"
                        }
```

I also clarified the docs, as it took me a bit to verify I had the URL correct.