### PR TITLE
Add emsdk as a git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -42,3 +42,6 @@
 [submodule "inference/3rd_party/browsermt-marian-dev"]
 	path = inference/3rd_party/browsermt-marian-dev
 	url = https://github.com/browsermt/marian-dev
+[submodule "inference/3rd_party/emsdk"]
+	path = inference/3rd_party/emsdk
+	url = https://github.com/emscripten-core/emsdk.git

--- a/inference/.gitignore
+++ b/inference/.gitignore
@@ -16,7 +16,6 @@ CTestTestfile.cmake
 _deps
 
 
-**/*/emsdk
 /build
 /build-local
 /build-native

--- a/inference/scripts/build-wasm.py
+++ b/inference/scripts/build-wasm.py
@@ -6,6 +6,10 @@ import shutil
 import subprocess
 from typing import Optional
 
+# The emsdk git submodule is set to revision 2346baa7bb44a4a0571cc75f1986ab9aaa35aa03 which
+# corresponds to version 3.1.8. The latest version of emsdk had errors building sentencepiece.
+EMSDK_VERSION = "3.1.8"
+
 SCRIPTS_PATH = os.path.realpath(os.path.dirname(__file__))
 INFERENCE_PATH = os.path.dirname(SCRIPTS_PATH)
 PROJECT_ROOT_PATH = os.path.dirname(INFERENCE_PATH)
@@ -20,10 +24,6 @@ PATCHES_PATH = os.path.join(INFERENCE_PATH, "patches")
 BUILD_DIRECTORY = os.path.join(INFERENCE_PATH, "build-wasm")
 GEMM_SCRIPT = os.path.join(INFERENCE_PATH, "wasm", "patch-artifacts-import-gemm-module.sh")
 DETECT_DOCKER_SCRIPT = os.path.join(SCRIPTS_PATH, "detect-docker.sh")
-
-# 3.1.47 had an error compiling sentencepiece.
-EMSDK_VERSION = "3.1.8"
-EMSDK_REVISION = "2346baa7bb44a4a0571cc75f1986ab9aaa35aa03"
 
 patches = [
     (MARIAN_PATH, os.path.join(PATCHES_PATH, "01-marian-fstream-for-macos.patch")),
@@ -58,41 +58,7 @@ def ensure_docker():
     )
 
 
-def git_clone_update(name: str, repo_path: str, repo_url: str, revision: str):
-    if not os.path.exists(repo_path):
-        print(f"\n⬇️ Clone the {name} repo into {repo_path}\n")
-        subprocess.check_call(
-            ["git", "clone", repo_url],
-            cwd=THIRD_PARTY_PATH,
-        )
-
-    local_head = subprocess.check_output(
-        ["git", "rev-parse", "HEAD"],
-        cwd=repo_path,
-        text=True,
-    ).strip()
-
-    def run(command):
-        return subprocess.check_call(command, cwd=repo_path)
-
-    if local_head != revision:
-        print(f"The head ({local_head}) and revision ({revision}) don't match.")
-        print(f"\n🔎 Fetching revision {revision} from {name}.\n")
-        run(["git", "fetch", "--recurse-submodules", "origin", revision])
-
-        print(f"🛒 Checking out the revision {revision}")
-        run(["git", "checkout", revision])
-        run(["git", "submodule", "update", "--init", "--checkout", "--recursive"])
-
-
-def install_and_activate_emscripten(args: ArgNamespace):
-    git_clone_update(
-        name="emsdk",
-        repo_path=EMSDK_PATH,
-        repo_url="https://github.com/emscripten-core/emsdk.git",
-        revision=EMSDK_REVISION,
-    )
-
+def install_and_activate_emscripten():
     # Run these commands in the shell so that the configuration is saved.
     def run_shell(command):
         return subprocess.run(command, cwd=EMSDK_PATH, shell=True, check=True)

--- a/inference/scripts/build-wasm.py
+++ b/inference/scripts/build-wasm.py
@@ -4,7 +4,7 @@ import multiprocessing
 import os
 import shutil
 import subprocess
-from collections import namedtuple
+from typing import Optional
 
 SCRIPTS_PATH = os.path.realpath(os.path.dirname(__file__))
 INFERENCE_PATH = os.path.dirname(SCRIPTS_PATH)
@@ -46,8 +46,6 @@ parser.add_argument(
     type=int,
     help="Number of cores to use for building (default: all available cores)",
 )
-
-ArgNamespace = namedtuple("ArgNamespace", ["clobber", "debug", "j"])
 
 
 def ensure_docker():
@@ -100,10 +98,10 @@ def install_and_activate_emscripten(args: ArgNamespace):
         return subprocess.run(command, cwd=EMSDK_PATH, shell=True, check=True)
 
     print(f"\n🛠️ Installing EMSDK version {EMSDK_VERSION}\n")
-    run_shell("./emsdk install " + EMSDK_VERSION)
+    run_shell(f"./emsdk install {EMSDK_VERSION}")
 
     print("\n🛠️ Activating emsdk\n")
-    run_shell("./emsdk activate " + EMSDK_VERSION)
+    run_shell(f"./emsdk activate {EMSDK_VERSION}")
 
 
 def to_human_readable(size):
@@ -131,7 +129,7 @@ def revert_git_patch(repo_path, patch_path):
     subprocess.check_call(["git", "apply", "-R", "--reject", patch_path], cwd=PROJECT_ROOT_PATH)
 
 
-def build_bergamot(args: ArgNamespace):
+def build_bergamot(args: Optional[list[str]]):
     if args.clobber and os.path.exists(BUILD_PATH):
         shutil.rmtree(BUILD_PATH)
 
@@ -201,7 +199,7 @@ def build_bergamot(args: ArgNamespace):
 
 
 def main():
-    args: ArgNamespace = parser.parse_args()
+    args = parser.parse_args()
 
     if not os.path.exists(THIRD_PARTY_PATH):
         os.mkdir(THIRD_PARTY_PATH)
@@ -210,7 +208,7 @@ def main():
 
     ensure_git_submodules()
 
-    install_and_activate_emscripten(args)
+    install_and_activate_emscripten()
 
     build_bergamot(args)
 


### PR DESCRIPTION
#902 reworked the WASM build script to use Python. It pulled some functionality from the pre-existing script within the Gecko source tree.

The Gecko script had to manually clone the `emsdk` repository, because we cannot add a proper git submodule in the Gecko source tree.

In this repository, however, we can and should use git submodules.

This patch removes the manual cloning of `emsdk` and adds it to the repository as a submodule. 