### PR TITLE
Make `npm` available to `local` and `inference` docker images

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -33,6 +33,28 @@ RUN apt-get update -qq \
                           python3-pybind11  \
          && apt-get clean
 
+ARG NVM_VERSION=0.40.1
+ARG NVM_CHECKSUM=abdb525ee9f5b48b34d8ed9fc67c6013fb0f659712e401ecd88ab989b3af8f53
+
+ARG NODE_VERSION=23.1.0
+ARG NODE_CHECKSUM=c438df636858200cffdfc3b579a1d784047da5c0e70dd647616c215726e254e2
+
+ARG NPM_VERSION=10.9.0
+ARG NPM_CHECKSUM=8e5f6f3429f8cdbe693cdc29904e9d5a7b127a494bd15c804bd54c7403bfcbe7
+
+RUN curl -o install.sh -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v${NVM_VERSION}/install.sh && \
+    echo "${NVM_CHECKSUM} install.sh" | sha256sum -c - && \
+    bash install.sh && \
+    export NVM_DIR="$HOME/.nvm" && \
+    [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" && \
+    nvm install ${NODE_VERSION} && \
+    nvm use ${NODE_VERSION} && \
+    echo "${NODE_CHECKSUM} $NVM_DIR/versions/node/$(nvm version)/bin/node" | sha256sum -c - && \
+    echo "${NPM_CHECKSUM} $NVM_DIR/versions/node/$(nvm version)/bin/npm" | sha256sum -c - && \
+    ln -sf "$NVM_DIR/versions/node/$(nvm version)/bin/node" /usr/local/bin/node && \
+    ln -sf "$NVM_DIR/versions/node/$(nvm version)/bin/npm" /usr/local/bin/npm && \
+    rm install.sh
+
 RUN mkdir /builds/worker/tools && \
     chown worker:worker /builds/worker/tools && \
     mkdir /builds/worker/tools/bin && \

--- a/taskcluster/docker/inference/Dockerfile
+++ b/taskcluster/docker/inference/Dockerfile
@@ -27,6 +27,28 @@ RUN apt-get update -qq \
                           libtool \
     && apt-get clean
 
+ARG NVM_VERSION=0.40.1
+ARG NVM_CHECKSUM=abdb525ee9f5b48b34d8ed9fc67c6013fb0f659712e401ecd88ab989b3af8f53
+
+ARG NODE_VERSION=23.1.0
+ARG NODE_CHECKSUM=c438df636858200cffdfc3b579a1d784047da5c0e70dd647616c215726e254e2
+
+ARG NPM_VERSION=10.9.0
+ARG NPM_CHECKSUM=8e5f6f3429f8cdbe693cdc29904e9d5a7b127a494bd15c804bd54c7403bfcbe7
+
+RUN curl -o install.sh -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v${NVM_VERSION}/install.sh && \
+    echo "${NVM_CHECKSUM} install.sh" | sha256sum -c - && \
+    bash install.sh && \
+    export NVM_DIR="$HOME/.nvm" && \
+    [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" && \
+    nvm install ${NODE_VERSION} && \
+    nvm use ${NODE_VERSION} && \
+    echo "${NODE_CHECKSUM} $NVM_DIR/versions/node/$(nvm version)/bin/node" | sha256sum -c - && \
+    echo "${NPM_CHECKSUM} $NVM_DIR/versions/node/$(nvm version)/bin/npm" | sha256sum -c - && \
+    ln -sf "$NVM_DIR/versions/node/$(nvm version)/bin/node" /usr/local/bin/node && \
+    ln -sf "$NVM_DIR/versions/node/$(nvm version)/bin/npm" /usr/local/bin/npm && \
+    rm install.sh
+
 RUN wget -O- https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB | apt-key add -
 COPY intel-mkl.list /etc/apt/sources.list.d/intel-mkl.list
 


### PR DESCRIPTION
This patch contains Docker changes that I will need for adding WASM JS tests to CI. 