### PR TITLE
fix: get rid of `hunspell` python package

### DIFF
--- a/taskcluster/kinds/bicleaner-model/kind.yml
+++ b/taskcluster/kinds/bicleaner-model/kind.yml
@@ -59,7 +59,6 @@ tasks:
                 - bash
                 - -c
                 - >-
-                    pip install $MOZ_FETCHES_DIR/hunspell-0.5.5-cp310-cp310-linux_x86_64.whl &&
                     pip install $MOZ_FETCHES_DIR/cyhunspell-2.0.3-cp310-cp310-linux_x86_64.whl &&
                     pip install $MOZ_FETCHES_DIR/kenlm-0.0.0-cp310-cp310-linux_x86_64.whl &&
                     pip install -r $VCS_PATH/pipeline/bicleaner/requirements/bicleaner-ai.txt &&
@@ -72,8 +71,6 @@ tasks:
 
         fetches:
             toolchain:
-                - artifact: hunspell
-                  extract: false
                 - artifact: cyhunspell
                   extract: false
                 - artifact: kenlm

--- a/taskcluster/kinds/bicleaner/kind.yml
+++ b/taskcluster/kinds/bicleaner/kind.yml
@@ -98,7 +98,6 @@ tasks:
                 # 4) number of threads to use - auto means nproc
                 # 5) "pack dir" - which needs to be where the `bicleaner-src-trg` fetch was unpacked to
                 - >-
-                    pip install $MOZ_FETCHES_DIR/hunspell-0.5.5-cp310-cp310-linux_x86_64.whl &&
                     pip install $MOZ_FETCHES_DIR/cyhunspell-2.0.3-cp310-cp310-linux_x86_64.whl &&
                     pip install $MOZ_FETCHES_DIR/kenlm-0.0.0-cp310-cp310-linux_x86_64.whl &&
                     pip install -r {bicleaner_reqs} &&
@@ -114,8 +113,6 @@ tasks:
             bicleaner-model: bicleaner-model-{src_locale}-{trg_locale}
         fetches:
             toolchain:
-                - artifact: hunspell
-                  extract: false
                 - artifact: cyhunspell
                   extract: false
                 - artifact: kenlm

--- a/taskcluster/kinds/fetch/python.yml
+++ b/taskcluster/kinds/fetch/python.yml
@@ -2,17 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 ---
-hunspell:
-    description: Hunspell 0.5.5 source
-    fetch:
-        type: static-url
-        url: https://files.pythonhosted.org/packages/e5/fe/cfc4dfd92c3a37c34d2806d5b84f9981bf3520db20149f8ee1a61f6fc69d/hunspell-0.5.5.tar.gz
-        sha256: 0f830b68bd8c392f4d5b4e21c38e28809e14d64ec67bde48272c920b63686f53
-        size: 34609
-        artifact-name: hunspell.tar.zst
-        strip-components: 1
-        add-prefix: hunspell/
-
 cyhunspell:
     description: cyhunspell 2.0.3 source
     fetch:

--- a/taskcluster/kinds/toolchain/kind.yml
+++ b/taskcluster/kinds/toolchain/kind.yml
@@ -139,17 +139,6 @@ tasks:
             fetch:
                 - kenlm
 
-    hunspell:
-        description: build hunspell binary wheel
-        run:
-            script: build-hunspell.sh
-            resources:
-                - taskcluster/scripts/toolchain/build-hunspell.sh
-            toolchain-artifact: public/build/hunspell-0.5.5-cp310-cp310-linux_x86_64.whl
-        fetches:
-            fetch:
-                - hunspell
-
     cyhunspell:
         description: build cyhunspell binary wheel
         run:


### PR DESCRIPTION
As far as I can tell, `cyhunspell` is a full on replacement for `hunspell`, to the point where the module name that is imported is the same. It looks to me that we're installing `hunspell`, and then immediately overwriting those files with `cyhunspell`, leaving the former unused.