### PR TITLE
feat: upgrade cpu workers to ubuntu 24.04 generic-worker image

### DIFF
--- a/taskcluster/config.yml
+++ b/taskcluster/config.yml
@@ -64,32 +64,32 @@ workers:
             provisioner: '{trust-domain}-{level}'
             implementation: docker-worker
             os: linux
-            worker-type: '{alias}'
+            worker-type: 'b-linux-large-gcp-d2g'
         b-linux-large-gcp-300gb:
             provisioner: '{trust-domain}-{level}'
             implementation: docker-worker
             os: linux
-            worker-type: '{alias}'
+            worker-type: 'b-linux-large-gcp-d2g-300gb'
         b-linux-large-gcp-1tb-32-256:
             provisioner: '{trust-domain}-{level}'
             implementation: docker-worker
             os: linux
-            worker-type: b-linux-large-gcp-1tb-32-256-d2g
+            worker-type: 'b-linux-large-gcp-1tb-32-256-d2g'
         b-linux-large-gcp-1tb-32-256-standard:
             provisioner: '{trust-domain}-{level}'
             implementation: docker-worker
             os: linux
-            worker-type: b-linux-large-gcp-1tb-32-256-std-d2g
+            worker-type: 'b-linux-large-gcp-1tb-32-256-std-d2g'
         b-linux-large-gcp-1tb-64-512:
             provisioner: '{trust-domain}-{level}'
             implementation: docker-worker
             os: linux
-            worker-type: b-linux-large-gcp-1tb-64-512-d2g
+            worker-type: 'b-linux-large-gcp-1tb-64-512-d2g'
         b-linux-large-gcp-1tb-64-512-standard:
             provisioner: '{trust-domain}-{level}'
             implementation: docker-worker
             os: linux
-            worker-type: b-linux-large-gcp-1tb-64-512-std-d2g
+            worker-type: 'b-linux-large-gcp-1tb-64-512-std-d2g'
         b-linux-v100-gpu:
             provisioner: '{trust-domain}-{level}'
             implementation: generic-worker


### PR DESCRIPTION
This will remove docker-worker from translations, and use the most recent generic-worker version instead. This halfway unblocks #375 and #466 (the other half is upgrading the GPU workers to this image, which is still in progress).

The other notable part of this is that it moves these workers to a common shared image that will be updated regularly. This means that we'll regularly be picking up things like Taskcluster version upgrades. There are risks to this of course, in that any change to the image can theoretically cause issues with tasks that use it. Over in https://github.com/mozilla-releng/fxci-config/pull/192, I'm working on adding the ability for us to run the training pipeline to help validate new images before they land to help minimize this.

We may also want to consider pinning to a specific image the next time we cut a `release` branch to minimize risk/change during long training sessions.

(If someone wants to make the case that we should always pin to a specific image rather than a rolling one, we can consider that.)