### PR TITLE
Add a warning when train- is the target stage rather than evaluate-

### DIFF
--- a/utils/trigger_training.py
+++ b/utils/trigger_training.py
@@ -95,6 +95,15 @@ def trigger_training(decision_task_id: str, config: dict[str, any]):
         },
     )
 
+    start_stage: str = config["target-stage"]
+    if start_stage.startswith("train"):
+        evaluate_stage = start_stage.replace("train-", "evaluate-")
+        red = "\033[91m"
+        reset = "\x1b[0m"
+        print(
+            f'\n{red}WARNING:{reset} target-stage is "{start_stage}", did you mean "{evaluate_stage}"'
+        )
+
     confirmation = input("\nStart training? [Y,n]\n")
     if confirmation and confirmation.lower() != "y":
         return


### PR DESCRIPTION
This is to guard against user error, as if you are targeting a train action, you usually want the evaluations too.