### PR TITLE
Rename "all" to "all-pipeline"

### DIFF
--- a/configs/autogenerated/bs-en-spring-2024.yml
+++ b/configs/autogenerated/bs-en-spring-2024.yml
@@ -111,7 +111,7 @@ marian-args:
     early-stopping: '20'
   training-student-finetuned:
     early-stopping: '20'
-target-stage: all
+target-stage: all-pipeline
 wandb-publication: true
 taskcluster:
   split-chunks: 20

--- a/configs/autogenerated/cs-en-spring-2024.yml
+++ b/configs/autogenerated/cs-en-spring-2024.yml
@@ -230,7 +230,7 @@ marian-args:
     early-stopping: '20'
   training-student-finetuned:
     early-stopping: '20'
-target-stage: all
+target-stage: all-pipeline
 wandb-publication: true
 taskcluster:
   split-chunks: 20

--- a/configs/autogenerated/da-en-spring-2024.yml
+++ b/configs/autogenerated/da-en-spring-2024.yml
@@ -230,7 +230,7 @@ marian-args:
     early-stopping: '20'
   training-student-finetuned:
     early-stopping: '20'
-target-stage: all
+target-stage: all-pipeline
 wandb-publication: true
 taskcluster:
   split-chunks: 20

--- a/configs/autogenerated/el-en-spring-2024.yml
+++ b/configs/autogenerated/el-en-spring-2024.yml
@@ -258,7 +258,7 @@ marian-args:
     early-stopping: '20'
   training-student-finetuned:
     early-stopping: '20'
-target-stage: all
+target-stage: all-pipeline
 wandb-publication: true
 taskcluster:
   split-chunks: 20

--- a/configs/autogenerated/en-bs-spring-2024.yml
+++ b/configs/autogenerated/en-bs-spring-2024.yml
@@ -111,7 +111,7 @@ marian-args:
     early-stopping: '20'
   training-student-finetuned:
     early-stopping: '20'
-target-stage: all
+target-stage: all-pipeline
 wandb-publication: true
 taskcluster:
   split-chunks: 20

--- a/configs/autogenerated/en-cs-spring-2024.yml
+++ b/configs/autogenerated/en-cs-spring-2024.yml
@@ -230,7 +230,7 @@ marian-args:
     early-stopping: '20'
   training-student-finetuned:
     early-stopping: '20'
-target-stage: all
+target-stage: all-pipeline
 wandb-publication: true
 taskcluster:
   split-chunks: 20

--- a/configs/autogenerated/en-da-spring-2024.yml
+++ b/configs/autogenerated/en-da-spring-2024.yml
@@ -230,7 +230,7 @@ marian-args:
     early-stopping: '20'
   training-student-finetuned:
     early-stopping: '20'
-target-stage: all
+target-stage: all-pipeline
 wandb-publication: true
 taskcluster:
   split-chunks: 20

--- a/configs/autogenerated/en-el-spring-2024.yml
+++ b/configs/autogenerated/en-el-spring-2024.yml
@@ -258,7 +258,7 @@ marian-args:
     early-stopping: '20'
   training-student-finetuned:
     early-stopping: '20'
-target-stage: all
+target-stage: all-pipeline
 wandb-publication: true
 taskcluster:
   split-chunks: 20

--- a/configs/autogenerated/en-fi-spring-2024.yml
+++ b/configs/autogenerated/en-fi-spring-2024.yml
@@ -237,7 +237,7 @@ marian-args:
     early-stopping: '20'
   training-student-finetuned:
     early-stopping: '20'
-target-stage: all
+target-stage: all-pipeline
 wandb-publication: true
 taskcluster:
   split-chunks: 20

--- a/configs/autogenerated/en-hr-spring-2024.yml
+++ b/configs/autogenerated/en-hr-spring-2024.yml
@@ -218,7 +218,7 @@ marian-args:
     early-stopping: '20'
   training-student-finetuned:
     early-stopping: '20'
-target-stage: all
+target-stage: all-pipeline
 wandb-publication: true
 taskcluster:
   split-chunks: 20

--- a/configs/autogenerated/en-hu-spring-2024.yml
+++ b/configs/autogenerated/en-hu-spring-2024.yml
@@ -186,7 +186,7 @@ marian-args:
     early-stopping: '20'
   training-student-finetuned:
     early-stopping: '20'
-target-stage: all
+target-stage: all-pipeline
 wandb-publication: true
 taskcluster:
   split-chunks: 20

--- a/configs/autogenerated/en-id-spring-2024.yml
+++ b/configs/autogenerated/en-id-spring-2024.yml
@@ -114,7 +114,7 @@ marian-args:
     early-stopping: '20'
   training-student-finetuned:
     early-stopping: '20'
-target-stage: all
+target-stage: all-pipeline
 wandb-publication: true
 taskcluster:
   split-chunks: 20

--- a/configs/autogenerated/en-lt-spring-2024.yml
+++ b/configs/autogenerated/en-lt-spring-2024.yml
@@ -186,7 +186,7 @@ marian-args:
     early-stopping: '20'
   training-student-finetuned:
     early-stopping: '20'
-target-stage: all
+target-stage: all-pipeline
 wandb-publication: true
 taskcluster:
   split-chunks: 20

--- a/configs/autogenerated/en-lv-spring-2024.yml
+++ b/configs/autogenerated/en-lv-spring-2024.yml
@@ -188,7 +188,7 @@ marian-args:
     early-stopping: '20'
   training-student-finetuned:
     early-stopping: '20'
-target-stage: all
+target-stage: all-pipeline
 wandb-publication: true
 taskcluster:
   split-chunks: 20

--- a/configs/autogenerated/en-ro-spring-2024.yml
+++ b/configs/autogenerated/en-ro-spring-2024.yml
@@ -214,7 +214,7 @@ marian-args:
     early-stopping: '20'
   training-student-finetuned:
     early-stopping: '20'
-target-stage: all
+target-stage: all-pipeline
 wandb-publication: true
 taskcluster:
   split-chunks: 20

--- a/configs/autogenerated/en-ru-spring-2024.yml
+++ b/configs/autogenerated/en-ru-spring-2024.yml
@@ -168,7 +168,7 @@ marian-args:
     early-stopping: '20'
   training-student-finetuned:
     early-stopping: '20'
-target-stage: all
+target-stage: all-pipeline
 wandb-publication: true
 taskcluster:
   split-chunks: 20

--- a/configs/autogenerated/en-sk-spring-2024.yml
+++ b/configs/autogenerated/en-sk-spring-2024.yml
@@ -175,7 +175,7 @@ marian-args:
     early-stopping: '20'
   training-student-finetuned:
     early-stopping: '20'
-target-stage: all
+target-stage: all-pipeline
 wandb-publication: true
 taskcluster:
   split-chunks: 20

--- a/configs/autogenerated/en-sl-spring-2024.yml
+++ b/configs/autogenerated/en-sl-spring-2024.yml
@@ -176,7 +176,7 @@ marian-args:
     early-stopping: '20'
   training-student-finetuned:
     early-stopping: '20'
-target-stage: all
+target-stage: all-pipeline
 wandb-publication: true
 taskcluster:
   split-chunks: 20

--- a/configs/autogenerated/en-sr-spring-2024.yml
+++ b/configs/autogenerated/en-sr-spring-2024.yml
@@ -124,7 +124,7 @@ marian-args:
     early-stopping: '20'
   training-student-finetuned:
     early-stopping: '20'
-target-stage: all
+target-stage: all-pipeline
 wandb-publication: true
 taskcluster:
   split-chunks: 20

--- a/configs/autogenerated/en-sv-spring-2024.yml
+++ b/configs/autogenerated/en-sv-spring-2024.yml
@@ -235,7 +235,7 @@ marian-args:
     early-stopping: '20'
   training-student-finetuned:
     early-stopping: '20'
-target-stage: all
+target-stage: all-pipeline
 wandb-publication: true
 taskcluster:
   split-chunks: 20

--- a/configs/autogenerated/en-tr-spring-2024.yml
+++ b/configs/autogenerated/en-tr-spring-2024.yml
@@ -139,7 +139,7 @@ marian-args:
     early-stopping: '20'
   training-student-finetuned:
     early-stopping: '20'
-target-stage: all
+target-stage: all-pipeline
 wandb-publication: true
 taskcluster:
   split-chunks: 20

--- a/configs/autogenerated/en-uk-spring-2024.yml
+++ b/configs/autogenerated/en-uk-spring-2024.yml
@@ -130,7 +130,7 @@ marian-args:
     early-stopping: '20'
   training-student-finetuned:
     early-stopping: '20'
-target-stage: all
+target-stage: all-pipeline
 wandb-publication: true
 taskcluster:
   split-chunks: 20

--- a/configs/autogenerated/en-vi-spring-2024.yml
+++ b/configs/autogenerated/en-vi-spring-2024.yml
@@ -108,7 +108,7 @@ marian-args:
     early-stopping: '20'
   training-student-finetuned:
     early-stopping: '20'
-target-stage: all
+target-stage: all-pipeline
 wandb-publication: true
 taskcluster:
   split-chunks: 20

--- a/configs/autogenerated/hr-en-spring-2024.yml
+++ b/configs/autogenerated/hr-en-spring-2024.yml
@@ -218,7 +218,7 @@ marian-args:
     early-stopping: '20'
   training-student-finetuned:
     early-stopping: '20'
-target-stage: all
+target-stage: all-pipeline
 wandb-publication: true
 taskcluster:
   split-chunks: 20

--- a/configs/autogenerated/id-en-spring-2024.yml
+++ b/configs/autogenerated/id-en-spring-2024.yml
@@ -113,7 +113,7 @@ marian-args:
     early-stopping: '20'
   training-student-finetuned:
     early-stopping: '20'
-target-stage: all
+target-stage: all-pipeline
 wandb-publication: true
 taskcluster:
   split-chunks: 20

--- a/configs/autogenerated/lt-en-spring-2024.yml
+++ b/configs/autogenerated/lt-en-spring-2024.yml
@@ -186,7 +186,7 @@ marian-args:
     early-stopping: '20'
   training-student-finetuned:
     early-stopping: '20'
-target-stage: all
+target-stage: all-pipeline
 wandb-publication: true
 taskcluster:
   split-chunks: 20

--- a/configs/autogenerated/lv-en-spring-2024.yml
+++ b/configs/autogenerated/lv-en-spring-2024.yml
@@ -188,7 +188,7 @@ marian-args:
     early-stopping: '20'
   training-student-finetuned:
     early-stopping: '20'
-target-stage: all
+target-stage: all-pipeline
 wandb-publication: true
 taskcluster:
   split-chunks: 20

--- a/configs/autogenerated/ro-en-spring-2024.yml
+++ b/configs/autogenerated/ro-en-spring-2024.yml
@@ -214,7 +214,7 @@ marian-args:
     early-stopping: '20'
   training-student-finetuned:
     early-stopping: '20'
-target-stage: all
+target-stage: all-pipeline
 wandb-publication: true
 taskcluster:
   split-chunks: 20

--- a/configs/autogenerated/ru-en-spring-2024.yml
+++ b/configs/autogenerated/ru-en-spring-2024.yml
@@ -172,7 +172,7 @@ marian-args:
     early-stopping: '20'
   training-student-finetuned:
     early-stopping: '20'
-target-stage: all
+target-stage: all-pipeline
 wandb-publication: true
 taskcluster:
   split-chunks: 20

--- a/configs/autogenerated/sk-en-spring-2024.yml
+++ b/configs/autogenerated/sk-en-spring-2024.yml
@@ -175,7 +175,7 @@ marian-args:
     early-stopping: '20'
   training-student-finetuned:
     early-stopping: '20'
-target-stage: all
+target-stage: all-pipeline
 wandb-publication: true
 taskcluster:
   split-chunks: 20

--- a/configs/autogenerated/sl-en-spring-2024.yml
+++ b/configs/autogenerated/sl-en-spring-2024.yml
@@ -176,7 +176,7 @@ marian-args:
     early-stopping: '20'
   training-student-finetuned:
     early-stopping: '20'
-target-stage: all
+target-stage: all-pipeline
 wandb-publication: true
 taskcluster:
   split-chunks: 20

--- a/configs/autogenerated/sr-en-spring-2024.yml
+++ b/configs/autogenerated/sr-en-spring-2024.yml
@@ -124,7 +124,7 @@ marian-args:
     early-stopping: '20'
   training-student-finetuned:
     early-stopping: '20'
-target-stage: all
+target-stage: all-pipeline
 wandb-publication: true
 taskcluster:
   split-chunks: 20

--- a/configs/autogenerated/sv-en-spring-2024.yml
+++ b/configs/autogenerated/sv-en-spring-2024.yml
@@ -235,7 +235,7 @@ marian-args:
     early-stopping: '20'
   training-student-finetuned:
     early-stopping: '20'
-target-stage: all
+target-stage: all-pipeline
 wandb-publication: true
 taskcluster:
   split-chunks: 20

--- a/configs/autogenerated/tr-en-spring-2024.yml
+++ b/configs/autogenerated/tr-en-spring-2024.yml
@@ -139,7 +139,7 @@ marian-args:
     early-stopping: '20'
   training-student-finetuned:
     early-stopping: '20'
-target-stage: all
+target-stage: all-pipeline
 wandb-publication: true
 taskcluster:
   split-chunks: 20

--- a/configs/autogenerated/vi-en-spring-2024.yml
+++ b/configs/autogenerated/vi-en-spring-2024.yml
@@ -108,7 +108,7 @@ marian-args:
     early-stopping: '20'
   training-student-finetuned:
     early-stopping: '20'
-target-stage: all
+target-stage: all-pipeline
 wandb-publication: true
 taskcluster:
   split-chunks: 20

--- a/configs/spring-2024/bs-en-spring-2024.yml
+++ b/configs/spring-2024/bs-en-spring-2024.yml
@@ -111,7 +111,7 @@ marian-args:
     early-stopping: '20'
   training-student-finetuned:
     early-stopping: '20'
-target-stage: all
+target-stage: all-pipeline
 start-stage: train-teacher
 previous_group_ids: ["M40EuFhERqSXuwlECYq9AQ"]
 existing_tasks: { "train-teacher-bs-en-1": "Mp4y39ByTSG29ibwj7toaQ" }

--- a/configs/spring-2024/cs-en-spring-2024.yml
+++ b/configs/spring-2024/cs-en-spring-2024.yml
@@ -230,7 +230,7 @@ marian-args:
     early-stopping: '20'
   training-student-finetuned:
     early-stopping: '20'
-target-stage: all
+target-stage: all-pipeline
 start-stage: evaluate-teacher-ensemble
 previous_group_ids: ["ThgMJX-PR4Kao_qkk4Aszw"]
 existing_tasks: { "train-vocab-cs-en": "SgJB5LMMRyuQoYxjwueZQA" }

--- a/configs/spring-2024/da-en-spring-2024.yml
+++ b/configs/spring-2024/da-en-spring-2024.yml
@@ -231,7 +231,7 @@ marian-args:
     early-stopping: '20'
   training-student-finetuned:
     early-stopping: '20'
-target-stage: all
+target-stage: all-pipeline
 start-stage: evaluate-quantized
 previous_group_ids: ["crE38R0zQO-SppXcyaSLYw"]
 wandb-publication: true

--- a/configs/spring-2024/el-en-spring-2024.yml
+++ b/configs/spring-2024/el-en-spring-2024.yml
@@ -269,7 +269,7 @@ marian-args:
     early-stopping: '20'
   training-student-finetuned:
     early-stopping: '20'
-target-stage: all
+target-stage: all-pipeline
 start-stage: merge-translated
 previous_group_ids: ["EE6ytMIqTOGUpjNr4rUtUA"]
 existing_tasks: { "train-vocab-el-en": "W60nDU12TWi7gVMtL30ZXQ", "train-teacher-el-en-2": "SO6jIGfVQpmBbfMmevxjnw" }

--- a/configs/spring-2024/en-cs-spring-2024.yml
+++ b/configs/spring-2024/en-cs-spring-2024.yml
@@ -232,7 +232,7 @@ marian-args:
     early-stopping: '20'
   training-student-finetuned:
     early-stopping: '20'
-target-stage: all
+target-stage: all-pipeline
 start-stage: train-student
 previous_group_ids: ["DtSyAeaVRoGNZDnUKscGWw"]
 existing_tasks: {

--- a/configs/spring-2024/en-da-spring-2024.yml
+++ b/configs/spring-2024/en-da-spring-2024.yml
@@ -236,7 +236,7 @@ marian-args:
     early-stopping: '20'
   training-student-finetuned:
     early-stopping: '20'
-target-stage: all
+target-stage: all-pipeline
 wandb-publication: true
 taskcluster:
   split-chunks: 20

--- a/configs/spring-2024/en-el-spring-2024.yml
+++ b/configs/spring-2024/en-el-spring-2024.yml
@@ -270,7 +270,7 @@ marian-args:
     early-stopping: '20'
   training-student-finetuned:
     early-stopping: '20'
-target-stage: all
+target-stage: all-pipeline
 start-stage: alignments-student
 previous_group_ids: ["Fv23lalyTfSfbmGx0YxypA"]
 existing_tasks: {

--- a/configs/spring-2024/en-fi-spring-2024.yml
+++ b/configs/spring-2024/en-fi-spring-2024.yml
@@ -238,7 +238,7 @@ marian-args:
     early-stopping: '20'
   training-student-finetuned:
     early-stopping: '20'
-target-stage: all
+target-stage: all-pipeline
 wandb-publication: true
 start-stage: train-student
 previous_group_ids: ["bNBrAkLqQpCpuxfMe3I-mw"]

--- a/configs/spring-2024/en-hr-spring-2024.yml
+++ b/configs/spring-2024/en-hr-spring-2024.yml
@@ -226,7 +226,7 @@ marian-args:
     early-stopping: '20'
   training-student-finetuned:
     early-stopping: '20'
-target-stage: all
+target-stage: all-pipeline
 wandb-publication: true
 taskcluster:
   split-chunks: 20

--- a/configs/spring-2024/en-hu-spring-2024.yml
+++ b/configs/spring-2024/en-hu-spring-2024.yml
@@ -191,7 +191,7 @@ marian-args:
     early-stopping: '20'
   training-student-finetuned:
     early-stopping: '20'
-target-stage: all
+target-stage: all-pipeline
 wandb-publication: true
 taskcluster:
   split-chunks: 20

--- a/configs/spring-2024/en-id-spring-2024.yml
+++ b/configs/spring-2024/en-id-spring-2024.yml
@@ -120,7 +120,7 @@ marian-args:
     early-stopping: '20'
   training-student-finetuned:
     early-stopping: '20'
-target-stage: all
+target-stage: all-pipeline
 start-stage: alignments-student
 previous_group_ids: ["B_zr10hIQm-17bJybx7cBQ"]
 existing_tasks: {

--- a/configs/spring-2024/en-lt-spring-2024.yml
+++ b/configs/spring-2024/en-lt-spring-2024.yml
@@ -193,7 +193,7 @@ marian-args:
     early-stopping: '20'
   training-student-finetuned:
     early-stopping: '20'
-target-stage: all
+target-stage: all-pipeline
 start-stage: evaluate-quantized
 previous_group_ids: ["EOXSsrVBRK6vL0R3_R0oRQ"]
 wandb-publication: true

--- a/configs/spring-2024/en-lv-spring-2024.yml
+++ b/configs/spring-2024/en-lv-spring-2024.yml
@@ -195,7 +195,7 @@ marian-args:
     early-stopping: '20'
   training-student-finetuned:
     early-stopping: '20'
-target-stage: all
+target-stage: all-pipeline
 wandb-publication: true
 taskcluster:
   split-chunks: 20

--- a/configs/spring-2024/en-ro-spring-2024.yml
+++ b/configs/spring-2024/en-ro-spring-2024.yml
@@ -222,7 +222,7 @@ marian-args:
     early-stopping: '20'
   training-student-finetuned:
     early-stopping: '20'
-target-stage: all
+target-stage: all-pipeline
 start-stage: alignments-student
 previous_group_ids: ["CYZBfFIXRV2qzROcGvlUHA"]
 existing_tasks: {

--- a/configs/spring-2024/en-ru-spring-2024.yml
+++ b/configs/spring-2024/en-ru-spring-2024.yml
@@ -177,7 +177,7 @@ marian-args:
     early-stopping: '20'
   training-student-finetuned:
     early-stopping: '20'
-target-stage: all
+target-stage: all-pipeline
 start-stage: alignments-student
 previous_group_ids: ["dOW0JdeoTFqFu431zzJ6Lw"]
 existing_tasks: {

--- a/configs/spring-2024/en-sk-spring-2024.yml
+++ b/configs/spring-2024/en-sk-spring-2024.yml
@@ -182,7 +182,7 @@ marian-args:
     early-stopping: '20'
   training-student-finetuned:
     early-stopping: '20'
-target-stage: all
+target-stage: all-pipeline
 start-stage: train-student
 previous_group_ids: ["f0U4TAUCQ6SYnK0BHpuuQA"]
 existing_tasks: {

--- a/configs/spring-2024/en-sl-spring-2024.yml
+++ b/configs/spring-2024/en-sl-spring-2024.yml
@@ -184,7 +184,7 @@ marian-args:
     early-stopping: '20'
   training-student-finetuned:
     early-stopping: '20'
-target-stage: all
+target-stage: all-pipeline
 wandb-publication: true
 taskcluster:
   split-chunks: 20

--- a/configs/spring-2024/en-sr-spring-2024.yml
+++ b/configs/spring-2024/en-sr-spring-2024.yml
@@ -130,7 +130,7 @@ marian-args:
     early-stopping: '20'
   training-student-finetuned:
     early-stopping: '20'
-target-stage: all
+target-stage: all-pipeline
 wandb-publication: true
 taskcluster:
   split-chunks: 20

--- a/configs/spring-2024/en-sv-spring-2024.yml
+++ b/configs/spring-2024/en-sv-spring-2024.yml
@@ -242,7 +242,7 @@ marian-args:
     early-stopping: '20'
   training-student-finetuned:
     early-stopping: '20'
-target-stage: all
+target-stage: all-pipeline
 start-stage: train-student
 previous_group_ids: ["NPlcq4JZRRCj0ksitTDSVw"]
 existing_tasks: {

--- a/configs/spring-2024/en-tr-spring-2024.yml
+++ b/configs/spring-2024/en-tr-spring-2024.yml
@@ -145,7 +145,7 @@ marian-args:
     early-stopping: '20'
   training-student-finetuned:
     early-stopping: '20'
-target-stage: all
+target-stage: all-pipeline
 start-stage: merge-translated
 previous_group_ids: ["MLewhxe-QQ2Ig7l0dHciGA"]
 existing_tasks: {

--- a/configs/spring-2024/en-uk-spring-2024.yml
+++ b/configs/spring-2024/en-uk-spring-2024.yml
@@ -135,7 +135,7 @@ marian-args:
     mini-batch: '2000'
   training-student-finetuned:
     early-stopping: '20'
-target-stage: all
+target-stage: all-pipeline
 start-stage: train-student
 previous_group_ids: ["LYBo_BrUR8mkopI3Js2czQ"]
 existing_tasks: {

--- a/configs/spring-2024/en-vi-spring-2024.yml
+++ b/configs/spring-2024/en-vi-spring-2024.yml
@@ -116,7 +116,7 @@ marian-args:
     early-stopping: '20'
   training-student-finetuned:
     early-stopping: '20'
-target-stage: all
+target-stage: all-pipeline
 wandb-publication: true
 existing_tasks: { "train-teacher-en-vi-2": "NJKF4w5NRIuHqql9-PkWwA" }
 taskcluster:

--- a/configs/spring-2024/hr-en-spring-2024.yml
+++ b/configs/spring-2024/hr-en-spring-2024.yml
@@ -220,7 +220,7 @@ marian-args:
     early-stopping: '20'
   training-student-finetuned:
     early-stopping: '20'
-target-stage: all
+target-stage: all-pipeline
 start-stage: evaluate-quantized
 previous_group_ids: ["T-jCOH1-RfK-fFaZ5bk3Mw"]
 wandb-publication: true

--- a/configs/spring-2024/id-en-spring-2024.yml
+++ b/configs/spring-2024/id-en-spring-2024.yml
@@ -114,7 +114,7 @@ marian-args:
     early-stopping: '20'
   training-student-finetuned:
     early-stopping: '20'
-target-stage: all
+target-stage: all-pipeline
 wandb-publication: true
 taskcluster:
   split-chunks: 20

--- a/configs/spring-2024/lt-en-spring-2024.yml
+++ b/configs/spring-2024/lt-en-spring-2024.yml
@@ -186,7 +186,7 @@ marian-args:
     early-stopping: '20'
   training-student-finetuned:
     early-stopping: '20'
-target-stage: all
+target-stage: all-pipeline
 start-stage: evaluate-quantized
 previous_group_ids: ["P-di8ZhOT0WZwTuBnXYxaA"]
 wandb-publication: true

--- a/configs/spring-2024/lv-en-spring-2024.yml
+++ b/configs/spring-2024/lv-en-spring-2024.yml
@@ -189,7 +189,7 @@ marian-args:
     early-stopping: '20'
   training-student-finetuned:
     early-stopping: '20'
-target-stage: all
+target-stage: all-pipeline
 start-stage: evaluate-quantized
 # The group with the proper first teacher that depends on the correct merge-mono-trg
 previous_group_ids: ["VadxViXgQxiIEQ_crRpF5g"]

--- a/configs/spring-2024/ro-en-spring-2024.yml
+++ b/configs/spring-2024/ro-en-spring-2024.yml
@@ -221,7 +221,7 @@ marian-args:
     early-stopping: '20'
   training-student-finetuned:
     early-stopping: '20'
-target-stage: all
+target-stage: all-pipeline
 start-stage: evaluate-teacher-ensemble
 previous_group_ids: ["dyZuhb9kQt2r7oQMA-1wcA"]
 existing_tasks: { "train-vocab-ro-en": "LrXhYkydScCL1KXpUEOu0Q" }

--- a/configs/spring-2024/ru-en-spring-2024.yml
+++ b/configs/spring-2024/ru-en-spring-2024.yml
@@ -169,7 +169,7 @@ marian-args:
     early-stopping: '20'
   training-student-finetuned:
     early-stopping: '20'
-target-stage: all
+target-stage: all-pipeline
 start-stage: evaluate-teacher-ensemble
 previous_group_ids: ["HI1HH_s1ROKqbIk4XPZkFg"]
 existing_tasks: { "train-vocab-ru-en": "Qx2YkFsDSq2hfheho5GAyA" }

--- a/configs/spring-2024/sk-en-spring-2024.yml
+++ b/configs/spring-2024/sk-en-spring-2024.yml
@@ -181,7 +181,7 @@ marian-args:
     early-stopping: '20'
   training-student-finetuned:
     early-stopping: '20'
-target-stage: all
+target-stage: all-pipeline
 start-stage: evaluate-teacher-ensemble
 previous_group_ids: ["MMUnGDb3ShGAFKjEDjU0zw"]
 existing_tasks: { "train-vocab-sk-en": "LVgzYH3aSDiUkZMZCx4mhQ" }

--- a/configs/spring-2024/sl-en-spring-2024.yml
+++ b/configs/spring-2024/sl-en-spring-2024.yml
@@ -177,7 +177,7 @@ marian-args:
     early-stopping: '20'
   training-student-finetuned:
     early-stopping: '20'
-target-stage: all
+target-stage: all-pipeline
 start-stage: evaluate-quantized
 previous_group_ids: ["BsYlEn2DQ2y_okj3oi1avA"]
 existing_tasks: { "train-vocab-sv-en": "Et8bOKpTQYywudvgDhX7mA" }

--- a/configs/spring-2024/sr-en-spring-2024.yml
+++ b/configs/spring-2024/sr-en-spring-2024.yml
@@ -124,7 +124,7 @@ marian-args:
     early-stopping: '20'
   training-student-finetuned:
     early-stopping: '20'
-target-stage: all
+target-stage: all-pipeline
 start-stage: train-teacher
 previous_group_ids: ["MnkWfZaTTUur5Q0vjw-Q1w"]
 existing_tasks: { "train-teacher-sr-en-1": "D8iHWHWJQ0uyFJhmCmsZ7g" }

--- a/configs/spring-2024/sv-en-spring-2024.yml
+++ b/configs/spring-2024/sv-en-spring-2024.yml
@@ -241,7 +241,7 @@ marian-args:
     early-stopping: '20'
   training-student-finetuned:
     early-stopping: '20'
-target-stage: all
+target-stage: all-pipeline
 start-stage: evaluate-teacher-ensemble
 previous_group_ids: ["ZNsC19vBRNiArhQmaIZxaA"]
 existing_tasks: { "train-vocab-sv-en": "Et8bOKpTQYywudvgDhX7mA" }

--- a/configs/spring-2024/tr-en-spring-2024.yml
+++ b/configs/spring-2024/tr-en-spring-2024.yml
@@ -139,7 +139,7 @@ marian-args:
     early-stopping: '20'
   training-student-finetuned:
     early-stopping: '20'
-target-stage: all
+target-stage: all-pipeline
 start-stage: train-teacher
 previous_group_ids: ["EmzSKf7LRh2ajZwnz301aw"]
 existing_tasks: { "train-teacher-tr-en-1": "FpfHl9uGRbu1X3U4rx4xYg" }

--- a/configs/spring-2024/uk-en-spring-2024.yml
+++ b/configs/spring-2024/uk-en-spring-2024.yml
@@ -130,7 +130,7 @@ marian-args:
     early-stopping: '20'
   training-student-finetuned:
     early-stopping: '20'
-target-stage: all
+target-stage: all-pipeline
 start-stage: evaluate-quantized
 previous_group_ids: ["Xz5QuLXISN-0zX-SJ56f8g"]
 wandb-publication: true

--- a/configs/spring-2024/vi-en-spring-2024.yml
+++ b/configs/spring-2024/vi-en-spring-2024.yml
@@ -110,7 +110,7 @@ marian-args:
     early-stopping: '20'
   training-student-finetuned:
     early-stopping: '20'
-target-stage: all
+target-stage: all-pipeline
 start-stage: train-teacher
 previous_group_ids: ["EYF-UaD5R82EN5sd-sGrCw"]
 existing_tasks: { "train-teacher-vi-en-1": "As_c47aLT9aPdCw8KpiSfQ" }

--- a/docs/task-cluster.md
+++ b/docs/task-cluster.md
@@ -84,7 +84,7 @@ so it's better to be careful with that when experimenting with the later stages 
 
 ## Running up to a specific step
 
-Change `target-stage: all` in the training config to a stage that corresponds to another TC step.
+Change `target-stage: all-pipeline` in the training config to a stage that corresponds to another TC step.
 For example, to download, clean and merge the training corpus use:
 ```
 target-stage: merge-corpus
@@ -106,7 +106,7 @@ When hacking on later parts of the pipeline it can often be useful to re-use ear
 
 ```
 start-stage: train-student
-target-stage: all
+target-stage: all-pipeline
 previous_group_ids: ["SsGpi3TGShaDT-h93fHL-g"]
 ```
 

--- a/taskcluster/config.yml
+++ b/taskcluster/config.yml
@@ -56,7 +56,8 @@ valid-stages:
     - evaluate-teacher-ensemble
     - analyze-corpus
     - analyze-mono
-    - all
+    - all-pipeline
+    - all-pr-pipeline
 
 workers:
     aliases:

--- a/taskcluster/configs/config.ci.yml
+++ b/taskcluster/configs/config.ci.yml
@@ -92,7 +92,7 @@ datasets:
 
 # Publishes to the "ci" project.
 wandb-publication: true
-target-stage: all
+target-stage: all-pipeline
 taskcluster:
   split-chunks: 2
   worker-classes:

--- a/taskcluster/configs/config.prod.yml
+++ b/taskcluster/configs/config.prod.yml
@@ -241,7 +241,7 @@ marian-args:
 # "merge-corpus". For more information see:
 #
 # https://mozilla.github.io/firefox-translations-training/task-cluster.html#running-up-to-a-specific-step
-target-stage: all
+target-stage: all-pipeline
 
 # Enable publication to Weights and Biases
 wandb-publication: true

--- a/taskcluster/kinds/all-pipeline/kind.yml
+++ b/taskcluster/kinds/all-pipeline/kind.yml
@@ -23,10 +23,10 @@ kind-dependencies:
     - analyze-mono
 
 tasks:
-    all:
+    all-pipeline:
         description: Dummy task that ensures all parts of training pipeline will run
         attributes:
-            stage: all
+            stage: all-pipeline
             src_locale: "{src_locale}"
             trg_locale: "{trg_locale}"
 

--- a/taskcluster/kinds/all-pr-pipeline/kind.yml
+++ b/taskcluster/kinds/all-pr-pipeline/kind.yml
@@ -13,7 +13,7 @@ transforms:
     - taskgraph.transforms.task:transforms
 
 # In order for tasks to be produced as "leaves" of the task graph, they must be attached
-# as dependencies to the "all" dummy task. This file is for full PR runs.
+# as dependencies to the "all-pr-pipeline" dummy task. This file is for full PR runs.
 kind-dependencies:
     - export
     - evaluate

--- a/taskcluster/test/params/large-lt-en.yml
+++ b/taskcluster/test/params/large-lt-en.yml
@@ -170,7 +170,7 @@ training_config:
       early-stopping: '20'
     training-teacher:
       early-stopping: '30'
-  target-stage: all
+  target-stage: all-pr-pipeline
   taskcluster:
     split-chunks: 10
     worker-classes:

--- a/taskcluster/test/test_default_params.py
+++ b/taskcluster/test/test_default_params.py
@@ -101,7 +101,7 @@ MOCK_REQUESTS = [
 
 def test_last_task_is_targeted(target_task_set: TaskGraph):
     """Ensure that the last task in the pipeline is targeted by default"""
-    assert any([task == "all-ru-en-1" for task in target_task_set.tasks])
+    assert any([task == "all-pipeline-ru-en-1" for task in target_task_set.tasks])
 
 
 def test_cached_tasks_optimized_away(optimized_task_graph: TaskGraph):

--- a/tests/fixtures/config.pytest.enzh.yml
+++ b/tests/fixtures/config.pytest.enzh.yml
@@ -55,7 +55,7 @@ marian-args:
     early-stopping: '20'
   training-student-finetuned:
     early-stopping: '20'
-target-stage: all
+target-stage: all-pr-pipeline
 taskcluster:
   split-chunks: 10
   worker-classes:

--- a/tests/fixtures/config.pytest.yml
+++ b/tests/fixtures/config.pytest.yml
@@ -67,7 +67,7 @@ marian-args:
     early-stopping: '20'
   training-student-finetuned:
     early-stopping: '20'
-target-stage: all
+target-stage: all-pr-pipeline
 taskcluster:
   split-chunks: 10
   worker-classes:

--- a/tests/test_preflight_check.py
+++ b/tests/test_preflight_check.py
@@ -42,7 +42,7 @@ def test_task_group():
     assert "Training config" not in output
     assert "Visualization" not in output
 
-    assert "all-en-ru-1" in output
+    assert "all-pipeline-en-ru-1" in output
     assert not opened_url
 
 

--- a/utils/preflight_check.py
+++ b/utils/preflight_check.py
@@ -172,7 +172,7 @@ def pretty_print_artifacts_dir() -> None:
             The full list of every task, such as.
             {
                "alignments-en-ru": { ... },
-               "all-en-ru-1": { ... },
+               "all-pipeline-en-ru-1": { ... },
                "bicleaner-opus-Books_v1-en-ru": { ... },
                ...
             }
@@ -180,7 +180,7 @@ def pretty_print_artifacts_dir() -> None:
         "label-to-taskid.json": """
             For example: {
               "alignments-en-ru": "CJwUWGPIQ4CdeinnE_NtNQ",
-              "all-en-ru-1": "DjZKX9lkTvmQDbnmFtNOBg",
+              "all-pipeline-en-ru-1": "DjZKX9lkTvmQDbnmFtNOBg",
               "bicleaner-opus-Books_v1-en-ru": "fukq_91DQ4S9verrlipC1A",
               ...
              }
@@ -193,7 +193,7 @@ def pretty_print_artifacts_dir() -> None:
             first round of tasks that can be run?
         """,
         "target-tasks.json": """
-            The dummy target for training, such as ["all-en-ru-1"]
+            The dummy target for training, such as ["all-pipeline-en-ru-1"]
         """,
         "task-graph.json": """
             The full task graph DAG. e.g.


### PR DESCRIPTION
This fixes the "all" to "all-pipeline" change.

I verified a full training run via: https://firefox-ci-tc.services.mozilla.com/tasks/groups/VKohAC8NTWazaqYK2OnhpA

```
task config-generator -- da en --name all-pipeline-test
task train -- --config configs/autogenerated/da-en-all-pipeline-test.yml --force
```

Two things were likely causing an issue, the prod config needed to be updated, and the valid stages need to have `all-pipeline` and `all-pr-pipeline` added to it.