### PR TITLE
Remove expired-after

### DIFF
--- a/taskcluster/kinds/alignments-backtranslated/kind.yml
+++ b/taskcluster/kinds/alignments-backtranslated/kind.yml
@@ -46,7 +46,6 @@ tasks:
                 - worker.env
                 - attributes
         worker-type: b-cpu-xlargedisk-32-256
-        expires-after: "90 days"
         worker:
             docker-image: {"in-tree": "train"}
             # 7 days

--- a/taskcluster/kinds/alignments-original/kind.yml
+++ b/taskcluster/kinds/alignments-original/kind.yml
@@ -45,7 +45,6 @@ tasks:
                 - worker.env
                 - attributes
         worker-type: b-cpu-xlargedisk-32-256
-        expires-after: "90 days"
         worker:
             docker-image: {"in-tree": "train"}
             # 7 days

--- a/taskcluster/kinds/alignments-student/kind.yml
+++ b/taskcluster/kinds/alignments-student/kind.yml
@@ -44,7 +44,6 @@ tasks:
                 - worker.env
                 - attributes
         worker-type: b-cpu-xlargedisk-32-256
-        expires-after: "90 days"
         worker:
             docker-image: {"in-tree": "train"}
             # 7 days

--- a/taskcluster/kinds/all/kind.yml
+++ b/taskcluster/kinds/all/kind.yml
@@ -38,7 +38,6 @@ tasks:
                 - attributes
 
         run-on-tasks-for: []
-        expires-after: "90 days"
         worker-type: succeed
 
         from-deps:

--- a/taskcluster/kinds/shortlist/kind.yml
+++ b/taskcluster/kinds/shortlist/kind.yml
@@ -45,7 +45,6 @@ tasks:
                 - worker.env
                 - attributes
         worker-type: b-cpu-xlargedisk-32-256
-        expires-after: "90 days"
         worker:
             docker-image: {"in-tree": "train"}
             # 7 days


### PR DESCRIPTION
Remove 90 days expiration and leave only root level 360 days one. I think it was added by mistake. As a result all our alignments tasks from spring2024 and other experiments have already expired.