### PR TITLE
use a hopefully more reliable mtdata dataset in ci config

### DIFF
--- a/taskcluster/configs/config.ci.yml
+++ b/taskcluster/configs/config.ci.yml
@@ -77,7 +77,7 @@ datasets:
     - opus_ada83/v1
     - opus_ELRC-3075-wikipedia_health/v1
     - url_https://storage.googleapis.com/releng-translations-dev/data/en-ru/pytest-dataset.[LANG].zst
-    - mtdata_ELRC-web_acquired_data_related_to_scientific_research-1-eng-rus
+    - mtdata_Tilde-airbaltic-1-eng-rus
   devtest:
     - flores_dev
     - sacrebleu_aug-upper_wmt19


### PR DESCRIPTION
The current mtdata dataset here has been unavailable for many days in a row, making it difficult to verify pipeline changes.

Should fix #974