### PR TITLE
Make Marian log parser more reliable

### DIFF
--- a/tracking/translations_parser/parser.py
+++ b/tracking/translations_parser/parser.py
@@ -213,8 +213,8 @@ class TrainingParser:
                 if not seq:
                     return None
                 if isinstance(seq[0], str):
-                    return "_".join(seq)
-                return _join([_join(item) for item in seq])
+                    return "_".join([item for item in seq if item is not None])
+                return _join([_join(item) for item in seq if item is not None])
 
             # Record logs depending on Marian headers
             tag = None


### PR DESCRIPTION
Sometimes Marian outputs something (maybe some errors) that breaks parsing and fails training. It's hard to say what exactly but this fix helps.