### PR TITLE
feat: enable chainOfTrust feature in decision task

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -225,6 +225,7 @@ tasks:
     
                               features:
                                   taskclusterProxy: true
+                                  chainOfTrust: true
     
                               image: mozillareleases/taskgraph:decision-v13.0.0@sha256:57e4c2d2ad92cea663dcc02cacbfd88b3506edde80e19fbd8a57b3dfe37ae9bd
                               maxRunTime: 1800


### PR DESCRIPTION
This enables chain of trust artifacts for the decision task, which will be needed for my work in #590. (Technically I could just enable it there, but it doesn't hurt to have now, and it will avoid some unnecessary docker image rebuilds.)