### PR TITLE
Use Standard Language Display for Languages

### DIFF
--- a/site/firefox-models/models.mjs
+++ b/site/firefox-models/models.mjs
@@ -86,7 +86,11 @@ async function main() {
   const models = records.data.filter((record) => record.fileType === "model");
   exposeAsGlobal("models", models);
 
-  const dn = new Intl.DisplayNames("en", { type: "language" });
+  const dn = new Intl.DisplayNames("en", {
+    type: "language",
+    fallback: "code",
+    languageDisplay: "standard",
+  });
 
   for (const model of models) {
     /** @type {ModelEntry | undefined} */


### PR DESCRIPTION
### Description

Switches the language DisplayNames config to use `"standard"` for the language display.

This will display "Chinese (Simplfied)" instead of "Simplified Chinese", which is nicer since our sorted order is by display name.

---

#### Before

![image](https://github.com/user-attachments/assets/77877df9-dc31-4e18-a2cc-eb9a45dc1fba)

#### After

![image](https://github.com/user-attachments/assets/c033b496-9532-43ed-973b-0eb977b6d41c)
