### PR TITLE
fix: remove unnecessary tool installs in kenlm build script

### DIFF
--- a/taskcluster/scripts/toolchain/build-kenlm.sh
+++ b/taskcluster/scripts/toolchain/build-kenlm.sh
@@ -4,16 +4,7 @@ set -x
 
 KENLM_DIR=$MOZ_FETCHES_DIR/kenlm-source
 
-# TODO: I don't think we actually need the C++ stuff? just the python module
-# build_dir=$(mktemp -d)
-# cd $build_dir
-# cmake $KENLM_DIR -DKENLM_MAX_ORDER=7
-# make -j$(nproc)
-
 cd $KENLM_DIR
-# Install these separately so they will install as wheels.
-# Using `--build-option` below disables wheels even for dependencies.
-pip install setuptools wheel cmake
 MAX_ORDER=7 python3 setup.py bdist_wheel
 find .
 cp $KENLM_DIR/dist/kenlm-0.0.0-cp310-cp310-linux_x86_64.whl $UPLOAD_DIR/


### PR DESCRIPTION
cmake 4.0 was released recently and its installation in this script is causing its toolchain build to fail.

I traced this back a bit and figure out exactly why we're doing it - cmake and the other tools were already installed on this docker image when this script was added. It was probably leftover from some early iteration of my work.