### PR TITLE
Normalize tabs to spaces

### DIFF
--- a/pipeline/clean/opuscleaner/clean-parallel.sh
+++ b/pipeline/clean/opuscleaner/clean-parallel.sh
@@ -37,8 +37,9 @@ python3 generate_filters.py "${input_prefix}" "${SRC}" "${TRG}" "${dataset}" "${
 test -s "${filter_path}" || exit 1
 
 echo "### Cleaning ${input_prefix} with filter ${filter_path}"
-paste <(zstdmt -dc "${input_prefix}.${SRC}.zst") \
-      <(zstdmt -dc "${input_prefix}.${TRG}.zst") |
+# Clean tabs before feeding into opuscleaner
+paste <(zstdmt -dc "${input_prefix}.${SRC}.zst" | sed 's|\t| |g') \
+      <(zstdmt -dc "${input_prefix}.${TRG}.zst" | sed 's|\t| |g') |
 opuscleaner-clean \
   --parallel ${threads} \
   --batch-size=50000 \


### PR DESCRIPTION
This is one of the changes from the Arabic experiments.

Some corpora contain tabs in the moses files separated by language, so when feeding to OpusCleaner it crashes. This change removes tabs before feeding OpusCleaner. It may be a bit hacky, so if you consider it should be implemented in a different way, I can try a different approach.