### PR TITLE
Add the student base-memory configuration

### DIFF
--- a/docs/training/README.md
+++ b/docs/training/README.md
@@ -214,8 +214,8 @@ teacher-ensemble: 1
 
 #### Student architecture
 
-"base" or "tiny" based on [Bergamot configurations](https://github.com/browsermt/students/tree/master/train-student/models).
-"tiny" is smaller and faster. "base" produces translations of higher quality.
+"base-memory", "base" or "tiny" based on [Bergamot configurations](https://github.com/browsermt/students/tree/master/train-student/models).
+"tiny" is smaller and faster. "base" produces translations of higher quality, and "base-memory" is a memory optimized version of "base".
 ```yaml
 student-model: tiny
 ```

--- a/pipeline/train/configs/model/student.base-memory.yml
+++ b/pipeline/train/configs/model/student.base-memory.yml
@@ -1,0 +1,38 @@
+# This configuration is a larger version of the original "tiny" model from:
+#
+# https://aclanthology.org/D19-5632.pdf
+# https://github.com/browsermt/students/tree/master/train-student/models/student.tiny11
+#
+# It solves the Pareto front of speed, memory, and quality, optimizing for all three.
+# It is competitive with the "base" model, but uses less memory and the download size
+# is smaller.
+#
+# This configuration is better for morphologically complex languages like Balto-Slavic
+# languages that feature heavy use of declensions, which changes the shape of words.
+#
+# https://docs.google.com/spreadsheets/d/1U2C4RqJXBqIMKvl6tqcyn8dvtn7bfvb7AuPHVW7JZ1g/edit?gid=1089483721#gid=1089483721
+# https://github.com/mozilla/translations/issues/174
+
+dec-cell-base-depth: 2
+dec-cell-high-depth: 1
+dec-cell: ssru
+dec-depth: 4 # This has been adjusted from 2 to 4 to increase the depth.
+dim-emb: 384 # Tiny is 256, and base is 512. This is in the middle.
+enc-cell-depth: 1
+enc-cell: gru
+enc-depth: 6
+enc-type: bidirectional
+tied-embeddings-all: true
+transformer-decoder-autoreg: rnn
+transformer-dim-ffn: 1536
+transformer-ffn-activation: relu
+transformer-ffn-depth: 2
+transformer-guided-alignment-layer: last
+transformer-heads: 8
+transformer-no-projection: false
+transformer-postprocess-emb: d
+transformer-postprocess: dan
+transformer-preprocess: ""
+transformer-tied-layers: []
+transformer-train-position-embeddings: false
+type: transformer

--- a/pipeline/train/train.py
+++ b/pipeline/train/train.py
@@ -39,6 +39,7 @@ class StudentModel(Enum):
     none = "None"
     tiny = "tiny"
     base = "base"
+    base_memory = "base-memory"
 
 
 class TeacherMode(Enum):

--- a/taskcluster/configs/config.prod.yml
+++ b/taskcluster/configs/config.prod.yml
@@ -102,9 +102,13 @@ experiment:
   teacher-mode: "two-stage"
   # Translate with either Marian, or CTranslate2.
   teacher-decoder: ctranslate2
-  # Two student training configurations from Bergamot are supported: "tiny" and "base"
-  # "base" model is twice slower and larger but adds ~2 COMET points in quality (see  https://github.com/mozilla/translations/issues/174)
-  student-model: "base"
+  # Choose a model architecture:
+  #   tiny - The original lightning fast model, which may suffer some quality issues.
+  #   base - A bigger model for complex languages. It is much larger in memory.
+  #   base-memory - Similar to base, but optimized for a smaller memory footprint.
+  #
+  # See: pipeline/train/configs/model/student.{student-model}.yml
+  student-model: "base-memory"
 
   # Training continuation options, see docs/using-pretrained-models.md
   pretrained-models:

--- a/taskcluster/translations_taskgraph/actions/train.py
+++ b/taskcluster/translations_taskgraph/actions/train.py
@@ -140,7 +140,7 @@ which allows for specifying task group ids to fetch existing tasks from.""",
                     "student-model": {
                         "type": "string",
                         "description": "Student model configuration",
-                        "enum": ["tiny", "base"],
+                        "enum": ["tiny", "base", "base-memory"],
                         "default": "tiny",
                     },
                     "mono-max-sentences-src": {


### PR DESCRIPTION
This is the result of the experiments from: #894
I believe we discussed this in the team meeting awhile back, but this is what I'm using on the h1-2024 run.

This is the `decoder-emb-384-depth-4` recipe from: [Student Architecture Quality and Speed Results](https://docs.google.com/spreadsheets/d/1U2C4RqJXBqIMKvl6tqcyn8dvtn7bfvb7AuPHVW7JZ1g/edit?gid=1089483721#gid=1089483721)