### PR TITLE
Build Marian with debug info

### DIFF
--- a/pipeline/setup/compile-marian.sh
+++ b/pipeline/setup/compile-marian.sh
@@ -19,11 +19,11 @@ cd "${marian_dir}"
 if [ "${use_gpu}" == "true" ]; then
   # this is a production version that runs on GPU
   test -v CUDA_DIR
-  cmake .. -DUSE_SENTENCEPIECE=on -DUSE_FBGEMM=on -DCOMPILE_CPU=on -DCMAKE_BUILD_TYPE=Release \
+  cmake .. -DUSE_SENTENCEPIECE=on -DUSE_FBGEMM=on -DCOMPILE_CPU=on -DCMAKE_BUILD_TYPE=RelWithDebInfo \
     -DCUDA_TOOLKIT_ROOT_DIR="${CUDA_DIR}" "${extra_args[@]}"
 else
   # this is a CPU version that we use for testing
-  cmake .. -DUSE_SENTENCEPIECE=on -DUSE_FBGEMM=on -DCOMPILE_CPU=on -DCMAKE_BUILD_TYPE=Release \
+  cmake .. -DUSE_SENTENCEPIECE=on -DUSE_FBGEMM=on -DCOMPILE_CPU=on -DCMAKE_BUILD_TYPE=RelWithDebInfo \
     -DCOMPILE_CUDA=off -DCOMPILE_SERVER=on "${extra_args[@]}"
 fi
 


### PR DESCRIPTION
This builds a release cut of Marian, but includes the debug information. This increases binary size, and maybe some memory usage as well, but otherwise the speed of the binary should be just as fast. I have this running on my `h1-2025` branch, and it's been useful to see the full stack traces of crashes within Marian.