### PR TITLE
MTdata fixes

### DIFF
--- a/pipeline/data/parallel_downloaders.py
+++ b/pipeline/data/parallel_downloaders.py
@@ -85,9 +85,25 @@ def mtdata(src: str, trg: str, dataset: str, output_prefix: Path):
     for file in tmp_dir.rglob("*"):
         logger.info(file)
 
-    for lang in (src, trg):
-        iso = iso3_code(lang, fail_error=True)
-        file = tmp_dir / "train-parts" / f"{dataset}.{iso}"
+    # some dataset names include BCP-47 country codes, e.g. OPUS-gnome-v1-eng-zho_CN
+    src_suffix = None
+    trg_suffix = None
+    iso_src = iso3_code(src, fail_error=True)
+    iso_trg = iso3_code(trg, fail_error=True)
+    parts = dataset.split("-")
+    code1, code2 = parts[-1], parts[-2]
+    # make sure iso369 code matches the begging of the mtdata langauge code (e.g. zho and zho_CN)
+    if code1.startswith(iso_src) and code2.startswith(iso_trg):
+        src_suffix = code1
+        trg_suffix = code2
+    elif code2.startswith(iso_src) and code1.startswith(iso_trg):
+        src_suffix = code2
+        trg_suffix = code1
+    else:
+        ValueError(f"Languages codes {code1}-{code2} do not match {iso_src}-{iso_trg}")
+
+    for lang, suffix in ((src, src_suffix), (trg, trg_suffix)):
+        file = tmp_dir / "train-parts" / f"{dataset}.{suffix}"
         compressed_path = compress_file(file, keep_original=False, compression="zst")
         compressed_path.rename(output_prefix.with_suffix(f".{lang}.zst"))
 

--- a/pipeline/data/parallel_downloaders.py
+++ b/pipeline/data/parallel_downloaders.py
@@ -108,7 +108,7 @@ def mtdata(src: str, trg: str, dataset: str, output_prefix: Path):
     iso_trg = iso3_code(trg, fail_error=True)
     parts = dataset.split("-")
     code1, code2 = parts[-1], parts[-2]
-    # make sure iso369 code matches the begging of the mtdata langauge code (e.g. zho and zho_CN)
+    # make sure iso369 code matches the beginning of the mtdata langauge code (e.g. zho and zho_CN)
     if code1.startswith(iso_src) and code2.startswith(iso_trg):
         src_suffix = code1
         trg_suffix = code2

--- a/tests/fixtures/config.pytest.enzh.yml
+++ b/tests/fixtures/config.pytest.enzh.yml
@@ -46,6 +46,7 @@ datasets:
     - opus_CCAligned/v1
     - opus_CCMatrix/v1
     - opus_ELRC-3075-wikipedia_health/v1
+    - mtdata_OPUS-gnome-v1-eng-zho_CN
   mono-src:
     - news-crawl_news.2021
     - news-crawl_news.2020

--- a/tests/test_data_importer.py
+++ b/tests/test_data_importer.py
@@ -107,6 +107,7 @@ def data_dir():
     "importer,src_lang,trg_lang,dataset",
     [
         ("mtdata", "en", "ru", "Neulab-tedtalks_test-1-eng-rus"),
+        ("mtdata", "en", "zh", "OPUS-gnome-v1-eng-zho_CN"),
         ("opus", "en", "ru", "ELRC-3075-wikipedia_health_v1"),
         ("opus", "ru", "en", "ELRC-3075-wikipedia_health_v1"),
         ("flores", "en", "ru", "dev"),

--- a/utils/config_generator.py
+++ b/utils/config_generator.py
@@ -222,10 +222,13 @@ def add_train_data(
     for corpus_key, entry in entries.items():
         if entry.did.name in skip_datasets:
             continue
+        modified_corpus_key = corpus_key
         # mtdata can have test and devtest data as well.
         if entry.did.name.endswith("test"):
             dataset = datasets["test"]
         elif entry.did.name.endswith("dev"):
+            dataset_name = corpus_key[corpus_key.find("_") + 1 :]
+            modified_corpus_key = f"mtdata_{aug_mix_modifier}_{dataset_name}"
             dataset = datasets["devtest"]
         else:
             dataset = datasets["train"]
@@ -244,7 +247,7 @@ def add_train_data(
 
         if fast:
             # Just add the dataset when in fast mode.
-            dataset.append(corpus_key)
+            dataset.append(modified_corpus_key)
         else:
             byte_size = None
             display_size = None
@@ -265,7 +268,7 @@ def add_train_data(
                 # Don't add the sentences to the total_sentences, as mtdata is less reliable
                 # compared to opus.
                 sentences = estimate_sentence_size(byte_size)
-                dataset.append(corpus_key)
+                dataset.append(modified_corpus_key)
                 if byte_size:
                     dataset.yaml_add_eol_comment(  # type: ignore
                         f"~{sentences:,} sentences ".rjust(70 - len(corpus_key), " ")

--- a/utils/config_generator.py
+++ b/utils/config_generator.py
@@ -46,6 +46,7 @@ skip_datasets = [
     "swedish_work_environment",
     # Fails to load from mtdata.
     "lithuanian_legislation_seimas_lithuania",
+    "Microsoft-ntrex",
     # Fails to load from OPUS.
     "SPC",
     # MTdata duplicates Flores that we pull directly


### PR DESCRIPTION
- fix BCP-47 codes
- exclude [ntrex](https://github.com/MicrosoftTranslator/NTREX) dataset (doesn't download, also it's an evaluation dataset)
- add retries (some ELRC datasets sometimes fail with read timeout)
- add augmentation to dev mtdata datasets in generated configs

closes #76 
closes #942 
closes #651 