### PR TITLE
fix: adjust dockerfile volumes to use new caches

### DIFF
--- a/taskcluster/docker/base/Dockerfile
+++ b/taskcluster/docker/base/Dockerfile
@@ -59,6 +59,6 @@ ENV SHELL=/bin/bash \
     TERM=hterm-256color
 
 VOLUME /builds/worker/checkouts
-VOLUME /builds/worker/.cache
+VOLUME /builds/worker/.task-cache/pip
 
 USER root

--- a/taskcluster/docker/inference/Dockerfile
+++ b/taskcluster/docker/inference/Dockerfile
@@ -68,6 +68,6 @@ ENV SHELL=/bin/bash \
     PATH="/builds/worker/.local/bin:$PATH"
 
 VOLUME /builds/worker/checkouts
-VOLUME /builds/worker/.cache
+VOLUME /builds/worker/.task-cache/pip
 
 USER root

--- a/taskcluster/docker/test/Dockerfile
+++ b/taskcluster/docker/test/Dockerfile
@@ -27,4 +27,4 @@ RUN curl -sSLf "https://github.com/go-task/task/releases/download/v3.35.1/task_l
     | tar -xz -C /usr/local/bin
 
 VOLUME /builds/worker/checkouts
-VOLUME /builds/worker/.cache
+VOLUME /builds/worker/.task-cache/pip

--- a/taskcluster/docker/toolchain-build/Dockerfile
+++ b/taskcluster/docker/toolchain-build/Dockerfile
@@ -45,6 +45,6 @@ ENV SHELL=/bin/bash \
     PATH="/builds/worker/.local/bin:$PATH"
 
 VOLUME /builds/worker/checkouts
-VOLUME /builds/worker/.cache
+VOLUME /builds/worker/.task-cache/pip
 
 USER root

--- a/taskcluster/docker/train/Dockerfile
+++ b/taskcluster/docker/train/Dockerfile
@@ -16,6 +16,5 @@ RUN apt-get update -qq \
                           wget \
     && apt-get clean
 
-
 VOLUME /builds/worker/checkouts
 VOLUME /builds/worker/.task-cache/pip


### PR DESCRIPTION
To try to work around https://github.com/mozilla/translations/issues/1117 I backed out much of https://github.com/mozilla/translations/issues/700. Notably, it reverted some changes to Dockerfile VOLUMEs. These volumes are taken into account when creating task definitions, which means that tasks created _with_ this backout applied require the images they run on to have been built with matching VOLUME definitions. Some of the more recent training runs were done with these new, post-#700 VOLUMEs, and trying to run training on them with #700 backed out is causing issues.

I'm not certain this will work, but let's give it a shot.