### PR TITLE
fix: pin to a specific version of taskcluster-taskgraph

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -227,6 +227,10 @@ tasks:
                                   taskclusterProxy: true
                                   chainOfTrust: true
     
+                              # The decision image version here should be kept
+                              # in sync with the two pins in pyproject.toml
+                              # to ensure that decision tasks & tests use the
+                              # same version of taskgraph
                               image: mozillareleases/taskgraph:decision-v14.2.1@sha256:f4e3a22df9ec0017a2534b3a7b4cd9b60318f86619e0c2156c12c1ec1a0e32cb
                               maxRunTime: 1800
                               onExitStatus:

--- a/poetry.lock
+++ b/poetry.lock
@@ -4845,4 +4845,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c64313675c0036f41fa6747f613d230ee4c689507f05da52ae6824d5f7664cc9"
+content-hash = "5a2d85ebf9237e398b06412b1a2b0ce1c6c7480fd14286d36e7dd868fc743236"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,11 @@ PyGithub="2.4.0"
 pyperclip="1.9.0"
 ruamel-yaml = "^0.18.6"
 taskcluster = "^56.0.3"
-taskcluster-taskgraph = "^14.2.1"
+# This package is specifically pinned to ensure the version stays in sync
+# between the two instances of it in this file, and the decision image version
+# pin in `.taskcluster.yml`. All three should be adjusted at the same time
+# to ensure that decision tasks & tests use the same version of taskgraph.
+taskcluster-taskgraph = "14.2.1"
 kinto-http="11.7.1"
 # Use an outdated version of pydantic due to dependency requirements conflict.
 pydantic="1.10.19"
@@ -69,7 +73,11 @@ requests-mock = "^1.11.0"
 sh = "^2.0.6"
 zstandard = "^0.22.0"
 translations_parser = {path="./tracking/", develop=true}
-taskcluster-taskgraph = "^14.2.1"
+# This package is specifically pinned to ensure the version stays in sync
+# between the two instances of it in this file, and the decision image version
+# pin in `.taskcluster.yml`. All three should be adjusted at the same time
+# to ensure that decision tasks & tests use the same version of taskgraph.
+taskcluster-taskgraph = "14.2.1"
 translations_taskgraph = {path="./taskcluster/", develop=true}
 sacremoses = "0.1.1"
 hanzidentifier = "1.2.0"


### PR DESCRIPTION
As discussed in https://github.com/mozilla/translations/pull/1120#discussion_r2091697494, pinning specifically (and adding comments) helps to ensure that what runs in production is the same thing used in tests.