### PR TITLE
Fix NTREX was not being ignored in config generator

### DIFF
--- a/utils/config_generator.py
+++ b/utils/config_generator.py
@@ -46,7 +46,7 @@ skip_datasets = [
     "swedish_work_environment",
     # Fails to load from mtdata.
     "lithuanian_legislation_seimas_lithuania",
-    "Microsoft-ntrex",
+    "ntrex",
     # Fails to load from OPUS.
     "SPC",
     # MTdata duplicates Flores that we pull directly


### PR DESCRIPTION
Created a config for Dutch and NTREX was in the training data. This should fix it.

I think this fix must be included in any H1-2025 training that starts from a new corpus. Just adding both of you to review so you get notified.