### PR TITLE
Re-use the local development container when possible

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -223,9 +223,16 @@ tasks:
     deps: [docker-build]
     summary: |
       The local docker image includes the Linux x86 image, and pre-built binaries
-      that are used in training.
+      that are used in training, and for building the inference engine.
+      The "translations-local-dev" container will be reused for each run.
+
+      - Start with a fresh container
+        task docker -- --clean
+
+      - Create a container with a different name
+        task docker -- --name translations-inference
     cmds:
-      - utils/tasks/docker-run.py bash
+      - utils/tasks/docker-run.py {{.CLI_ARGS}} bash
 
   docker-run:
     desc: Run a command in the local docker instance. e.g. `docker-run -- echo "hello"`

--- a/utils/tasks/docker-run.py
+++ b/utils/tasks/docker-run.py
@@ -51,7 +51,7 @@ def container_exists(container_name: str):
         "--all",
         "--filter", f"name={container_name}",
         "--format", "{{.Names}}"
-    ] # fmt: skip
+    ]  # fmt: skip
     result = subprocess.run(
         command,
         stdout=subprocess.PIPE,

--- a/utils/tasks/docker-run.py
+++ b/utils/tasks/docker-run.py
@@ -6,6 +6,9 @@ import os
 import platform
 import sys
 
+CONTAINER_NAME = "translations-local-dev"
+IMAGE_NAME = "translations-local"
+
 
 def get_args():
     parser = argparse.ArgumentParser(description="Run the local docker image.")
@@ -23,50 +26,94 @@ def get_args():
         help="Run the Docker container as the current user's UID and GID.",
     )
 
+    parser.add_argument(
+        "--clean",
+        action="store_true",
+        help="Remove any existing container before starting a new one.",
+    )
+
+    parser.add_argument(
+        "--name",
+        type=str,
+        default=CONTAINER_NAME,
+        help="Provide a custom container name",
+    )
+
     args, other_args = parser.parse_known_args()
     args.other_args = other_args
 
     return args
 
 
+def container_exists(container_name: str):
+    command = [
+        "docker", "ps",
+        "--all",
+        "--filter", f"name={container_name}",
+        "--format", "{{.Names}}"
+    ] # fmt: skip
+    result = subprocess.run(
+        command,
+        stdout=subprocess.PIPE,
+        text=True,
+        check=False,
+    )
+    return container_name in result.stdout.splitlines()
+
+
 def main():
     args = get_args()
 
-    docker_command = [
-        "docker",
-        "run",
-        "--interactive",
-        "--tty",
-        "--rm",
-        "--volume", f"{os.getcwd()}:/builds/worker/checkouts",
-        "--workdir", "/builds/worker/checkouts",
-        "--expose", "8000", # Expose the mkdocs connection
-    ]  # fmt: skip
+    container_name: str = args.name
 
-    # Export the host operating system as an environment variable within the container.
-    host_os = platform.system()
-    docker_command.extend(["--env", f"HOST_OS={host_os}"])
+    if args.clean and container_exists(container_name):
+        print(f'[docker-run] Removing the "{container_name}" container')
+        subprocess.run(["docker", "container", "rm", "--force", container_name], check=True)
 
-    # Add additional volumes if provided
-    if args.volume:
-        for volume in args.volume:
-            docker_command.extend(["--volume", volume])
+    if container_exists(container_name):
+        print(f"[docker-run] Attaching to the existing container {container_name}")
+        result = subprocess.run(
+            ["docker", "container", "start", "--attach", "--interactive", container_name],
+            check=False,
+        )
+    else:
+        # Create and run the container.
+        docker_command = [
+            "docker", "container", "run",
+            "--interactive",
+            "--tty",
+            "--name", container_name,
+            "--volume", f"{os.getcwd()}:/builds/worker/checkouts",
+            "--workdir", "/builds/worker/checkouts",
+            "--publish", "8000:8000",
+            "--publish", "8080:8080"
+        ]  # fmt: skip
 
-    # Run Docker with the current user's UID and GID if --run-as-user is specified
-    if args.run_as_user:
-        uid = os.getuid()
-        gid = os.getgid()
-        docker_command.extend(["--user", f"{uid}:{gid}"])
+        # Export the host operating system as an environment variable within the container.
+        host_os = platform.system()
+        docker_command.extend(["--env", f"HOST_OS={host_os}"])
 
-    # Specify the Docker image
-    docker_command.append("translations-local")
+        # Add additional volumes if provided
+        if args.volume:
+            for volume in args.volume:
+                docker_command.extend(["--volume", volume])
 
-    # Append any additional args
-    if args.other_args:
-        docker_command.extend(args.other_args)
+        # Run Docker with the current user's UID and GID if --run-as-user is specified
+        if args.run_as_user:
+            uid = os.getuid()
+            gid = os.getgid()
+            docker_command.extend(["--user", f"{uid}:{gid}"])
 
-    print("Executing command:", " ".join(docker_command))
-    result = subprocess.run(docker_command, check=False)
+        # Specify the Docker image
+        docker_command.append("translations-local")
+
+        # Append any additional args
+        if args.other_args:
+            docker_command.extend(args.other_args)
+
+        print("[docker-run] Running:", " ".join(docker_command))
+        result = subprocess.run(docker_command, check=False)
+
     sys.exit(result.returncode)
 
 

--- a/utils/tasks/docker-run.py
+++ b/utils/tasks/docker-run.py
@@ -105,7 +105,7 @@ def main():
             docker_command.extend(["--user", f"{uid}:{gid}"])
 
         # Specify the Docker image
-        docker_command.append("translations-local")
+        docker_command.append(IMAGE_NAME)
 
         # Append any additional args
         if args.other_args:


### PR DESCRIPTION
We were always creating and destroying containers when attaching to them, which can be negative when working locally, as you can't have any persistent state. The old behavior can be retained by passing in `task docker -- --clean`. This allows for a more stable local development process when running docker.