### PR TITLE
Upgrade bicleaner and update the GPU requirement step

### DIFF
--- a/pipeline/bicleaner/bicleaner.sh
+++ b/pipeline/bicleaner/bicleaner.sh
@@ -10,6 +10,9 @@ set -euo pipefail
 
 echo "###### Bicleaner filtering"
 
+echo "First check that GPUs are available."
+python3 -c "from pipeline.common.marian import assert_gpus_available; assert_gpus_available()"
+
 test -v SRC
 test -v TRG
 test -v CUDA_DIR
@@ -70,7 +73,7 @@ else
                # to operate on the CPU very slowly. To guard against this wasting expensive
                # GPU time, always check that it can find GPUs.
                python3 -c "import tensorflow; exit(0) if tensorflow.config.list_physical_devices('GPU') else exit(75)"
-               bicleaner-ai-classify --disable_hardrules --scol ${scol} --tcol ${tcol} - - $1
+               bicleaner-ai-classify --disable_hardrules --require_gpu --scol ${scol} --tcol ${tcol} - - $1
        }
        export -f biclean
        # {%} is a 1-indexed job slot number from GNU parallel.  We use that as the 1-indexed offset in CUDA_VISIBLE_ARRAY

--- a/pipeline/bicleaner/requirements/bicleaner-ai.in
+++ b/pipeline/bicleaner/requirements/bicleaner-ai.in
@@ -1,4 +1,4 @@
 # Note: this package is installed manually before the rest of the requirements
 # using the toolchain taskcluster/kinds/toolchain/kind.yml
 cython_hunspell==2.0.3
-bicleaner-ai==3.0.1
+bicleaner-ai==3.2.1

--- a/pipeline/bicleaner/requirements/bicleaner-ai.txt
+++ b/pipeline/bicleaner/requirements/bicleaner-ai.txt
@@ -10,7 +10,7 @@ absl-py==2.1.0
     #   tensorflow
 astunparse==1.6.3
     # via tensorflow
-bicleaner-ai==3.0.1
+bicleaner-ai==3.2.1
     # via -r reqs.in
 bicleaner-ai-glove==0.2.1
     # via bicleaner-ai

--- a/pipeline/common/marian.py
+++ b/pipeline/common/marian.py
@@ -9,6 +9,8 @@ import subprocess
 from pathlib import Path
 from typing import Union
 
+from pipeline.common.logging import get_logger
+
 import yaml
 
 
@@ -57,7 +59,7 @@ def marian_args_to_dict(extra_marian_args: list[str]) -> dict[str, Union[str, bo
     return decoder_config
 
 
-def assert_gpus_available(logger: Logger) -> None:
+def assert_gpus_available(logger: Logger = get_logger("gpu_check")) -> None:
     """
     Sometimes the GPUs aren't available when running tasks on GPU machines in the cloud.
     This function reports on the GPUs available, and exits the task with an

--- a/taskcluster/kinds/corpus-clean-parallel-bicleaner-ai/kind.yml
+++ b/taskcluster/kinds/corpus-clean-parallel-bicleaner-ai/kind.yml
@@ -102,6 +102,7 @@ tasks:
                     pip install $MOZ_FETCHES_DIR/cyhunspell-2.0.3-cp310-cp310-linux_x86_64.whl &&
                     pip install $MOZ_FETCHES_DIR/kenlm-0.0.0-cp310-cp310-linux_x86_64.whl &&
                     pip install -r {bicleaner_reqs} &&
+                    export PYTHONPATH=$PYTHONPATH:$VCS_PATH &&
                     export PATH=$PATH:~/.local/bin &&
                     $VCS_PATH/pipeline/bicleaner/bicleaner.sh
                     $MOZ_FETCHES_DIR/{dataset_sanitized}


### PR DESCRIPTION
This does the GPU check earlier, with the nicer output of `assert_gpus_available`, and updates bicleaner to use the new `--require_gpu` step.