### PR TITLE
Use 10 training updates in CI tasks

### DIFF
--- a/pipeline/train/train.py
+++ b/pipeline/train/train.py
@@ -2,6 +2,8 @@
 Run training using Marian and OpusTrainer.
 """
 
+# cache bust
+
 import argparse
 import filecmp
 from contextlib import ExitStack

--- a/taskcluster/configs/config.ci.yml
+++ b/taskcluster/configs/config.ci.yml
@@ -54,28 +54,28 @@ marian-args:
     # Run training for 10 updates, and display 5 updates. Only validate and save the
     # model once.
     disp-freq: "2"
-    save-freq: "25"
-    valid-freq: "50"
-    after: 50u
+    save-freq: "5"
+    valid-freq: "10"
+    after: 10u
     dim-vocabs: "1000 1000"
   training-teacher:
     disp-freq: "1"
-    save-freq: "25"
-    valid-freq: "50"
-    after: 50u
+    save-freq: "5"
+    valid-freq: "10"
+    after: 10u
     dim-vocabs: "1000 1000"
     task: transformer-base
   training-student:
     disp-freq: "1"
-    save-freq: "25"
-    valid-freq: "50"
-    after: 50u
+    save-freq: "5"
+    valid-freq: "10"
+    after: 10u
     dim-vocabs: "1000 1000"
   training-student-finetuned:
     disp-freq: "1"
-    save-freq: "25"
-    valid-freq: "50"
-    after: 50u
+    save-freq: "5"
+    valid-freq: "10"
+    after: 10u
     dim-vocabs: 1000 1000
   decoding-backward:
     mini-batch-words: "2000"


### PR DESCRIPTION
I was doing some profiling around task times, and teacher training in CI was 13 minutes, with 11 minutes being training. Seems like we just need a few updates to prove it works. I reduced the updates to a 1/5 of the original.

https://share.firefox.dev/3HLGYMg