### PR TITLE
Remove tied embeddings parameter from student base-memory config

### DIFF
--- a/pipeline/train/configs/model/student.base-memory.yml
+++ b/pipeline/train/configs/model/student.base-memory.yml
@@ -22,7 +22,6 @@ enc-cell-depth: 1
 enc-cell: gru
 enc-depth: 6
 enc-type: bidirectional
-tied-embeddings-all: true
 transformer-decoder-autoreg: rnn
 transformer-dim-ffn: 1536
 transformer-ffn-activation: relu
@@ -36,3 +35,4 @@ transformer-preprocess: ""
 transformer-tied-layers: []
 transformer-train-position-embeddings: false
 type: transformer
+# tied-embeddings* parameters are applied based on using shared or separate vocabs


### PR DESCRIPTION
I thought there was a bug but luckily `train.py` overrides `tied-embeddings-all` with split vocabs. Still it's better to remove it to make it in sync with other student configs and prevent issues in the future.