### PR TITLE
Firefox models site refresh

### DIFF
--- a/site/@types/models.d.ts
+++ b/site/@types/models.d.ts
@@ -1,0 +1,49 @@
+type LangPairStr = string
+type DatasetStr = string
+type TranslatorStr = string;
+type ScoreNum = number;
+
+type EvalResults = Record<LangPairStr, Record<DatasetStr, Record<TranslatorStr, ScoreNum>>>;
+
+/**
+ * For Remote Settings, the JSON details about the attachment.
+ */
+export interface Attachment {
+  // e.g. "2f7c0f7bbc...ca79f0850c4de",
+ hash: string;
+ // e.g. 5047568,
+ size: string;
+ // e.g. "lex.50.50.deen.s2t.bin",
+ filename: string;
+ // e.g. "main-workspace/translations-models/316ebb3a-0682-42cc-8e73-a3ba4bbb280f.bin",
+ location: string;
+ // e.g. "application/octet-stream"
+ mimetype: string;
+}
+
+/**
+ * The JSON that is synced from Remote Settings for the translation models.
+ */
+export interface ModelRecord {
+ // e.g. "0d4db293-a17c-4085-9bd8-e2e146c85000"
+ id: string;
+ // The full model name, e.g. "lex.50.50.deen.s2t.bin"
+ name: string;
+ // The BCP 47 language tag, e.g. "de"
+ fromLang: string;
+ // The BCP 47 language tag, e.g. "en"
+ toLang: string;
+ // The semver number, used for handling future format changes. e.g. 1.0
+ version: string;
+ // e.g. "lex"
+ fileType: string;
+ // The file attachment for this record
+ attachment: Attachment;
+ // e.g. 1673023100578
+ schema: number;
+ // e.g. 1673455932527
+ last_modified: string;
+ // A JEXL expression to determine whether this record should be pulled from Remote Settings
+ // See: https://remote-settings.readthedocs.io/en/latest/target-filters.html#filter-expressions
+ filter_expression: string;
+}

--- a/site/@types/models.d.ts
+++ b/site/@types/models.d.ts
@@ -47,3 +47,11 @@ export interface ModelRecord {
  // See: https://remote-settings.readthedocs.io/en/latest/target-filters.html#filter-expressions
  filter_expression: string;
 }
+
+export interface ReleaseInfo {
+  release: boolean,
+  beta: boolean,
+  nightly: boolean,
+  android: boolean,
+  label: string,
+}

--- a/site/@types/utils.d.ts
+++ b/site/@types/utils.d.ts
@@ -1,5 +1,7 @@
-
-export interface CreateElementOptions<T> {
+/**
+ * The interface used by the createElements utility.
+ */
+export interface CreateElementOptions {
   style: Partial<CSSStyleDeclaration>,
   parent: Element,
   children: Node | string | Array<string | Node> | [],

--- a/site/firefox-models/index.html
+++ b/site/firefox-models/index.html
@@ -34,6 +34,8 @@
   <div class='flex-center-container'>
 
     <div class="settings">
+      <input type='checkbox' id="releasedModels" />
+      <label for="releasedModels">Released Models Only</label><br/>
       <input type='checkbox' id="remoteSettingsPreview" />
       <label for="remoteSettingsPreview">Use Remote Settings "Preview"</label>
     </div>
@@ -53,7 +55,7 @@
             <td id="toProd"></td>
           </tr>
           <tr>
-            <th>Nightly</th>
+            <th>Nightly or Beta</th>
             <td id="fromNightly"></td>
             <td id="toNightly"></td>
           </tr>
@@ -69,15 +71,14 @@
           <thead>
             <tr>
               <th>Language</th>
-              <th>Model</th>
               <th>Version</th>
+              <th>Model</th>
               <th>Size</th>
               <th>Release</th>
               <th title="The model must be within 5% COMET evaluation score of Google's models to be shippable">
                 Score
               </th>
               <th>Model</th>
-              <th>Version</th>
               <th>Size</th>
               <th>Release</th>
               <th title="The model must be within 5% COMET evaluation score of Google's models to be shippable">

--- a/site/firefox-models/models.css
+++ b/site/firefox-models/models.css
@@ -39,8 +39,14 @@
   /* Language Name */
   & :is(th, td):nth-child(1) {
     font-weight: bold;
+    padding-right: 0;
+  }
+
+  /* Version Name */
+  & :is(th, td):nth-child(2) {
     border-right: 2px solid #aaa;
     text-align: right;
+    padding-left: 0;
   }
 
   & :is(th, td):nth-child(7) {
@@ -48,12 +54,13 @@
   }
 
   /* models */
-  & td:is(:nth-child(2), :nth-child(7)) {
+  & td:is(:nth-child(3), :nth-child(7)) {
     background-color: #0001;
     font-family: monospace;
   }
 
-  & :is(th, td):is(:nth-child(2), :nth-child(7)) {
+  /* Size */
+  & :is(td):is(:nth-child(4), :nth-child(8)) {
     text-align: right;
   }
 

--- a/site/firefox-models/models.mjs
+++ b/site/firefox-models/models.mjs
@@ -2,7 +2,7 @@
 import { changeLocation, exposeAsGlobal, getElement } from "../utils.mjs";
 
 /**
- * @import { ModelRecord, EvalResults } from "../@types/models"
+ * @import { ModelRecord, EvalResults, ReleaseInfo } from "../@types/models"
  */
 
 main().catch((error) => {
@@ -29,15 +29,13 @@ async function fetchJSON(url) {
   return await response.json();
 }
 
-async function main() {
-  getElement("counts").style.display = "table";
-
+function setupRemoteSettingsPreview() {
   const remoteSettingsPreviewCheckbox = /** @type {HTMLInputElement} */ (
     getElement("remoteSettingsPreview")
   );
   const urlParams = new URLSearchParams(window.location.search);
-  const isPreview = urlParams.get("preview");
-  remoteSettingsPreviewCheckbox.checked = isPreview === "true";
+  const isPreview = urlParams.get("preview") === "true";
+  remoteSettingsPreviewCheckbox.checked = isPreview;
   remoteSettingsPreviewCheckbox.addEventListener("change", () => {
     const urlParams = new URLSearchParams(window.location.search);
     if (remoteSettingsPreviewCheckbox.checked) {
@@ -47,8 +45,37 @@ async function main() {
     }
     changeLocation(urlParams);
   });
+  return isPreview;
+}
 
+function setupReleasedModels() {
+  const releasedModelsCheckbox = /** @type {HTMLInputElement} */ (
+    getElement("releasedModels")
+  );
+  const urlParams = new URLSearchParams(window.location.search);
+  const urlValue = urlParams.get("releasedModels");
+  const isReleasedModels = urlValue === "true" || !urlValue;
+  releasedModelsCheckbox.checked = isReleasedModels;
+  releasedModelsCheckbox.addEventListener("change", () => {
+    const urlParams = new URLSearchParams(window.location.search);
+    if (releasedModelsCheckbox.checked) {
+      urlParams.delete("releasedModels");
+    } else {
+      urlParams.set("releasedModels", "false");
+    }
+    changeLocation(urlParams);
+  });
+
+  return isReleasedModels;
+}
+
+async function main() {
+  getElement("counts").style.display = "table";
+
+  const isPreview = setupRemoteSettingsPreview();
   const bucket = isPreview ? "main-preview" : "main";
+
+  const isReleasedModels = setupReleasedModels();
 
   /** @type {{ data: ModelRecord[] }} */
   const records = await fetchJSON(
@@ -71,13 +98,17 @@ async function main() {
    * @property {string} lang
    * @property {string} version
    * @property {string} display
-   * @property {ModelRecord[]} fromEn
-   * @property {ModelRecord[]} toEn
+   * @property {ModelRecord | null} fromEn
+   * @property {ModelRecord | null} toEn
    */
 
   /** @type {Map<string, ModelEntry>} */
   const modelsMap = new Map();
-  const models = records.data.filter((record) => record.fileType === "model");
+  let models = records.data.filter((record) => record.fileType === "model");
+
+  if (isReleasedModels) {
+    models = models.filter((model) => getReleaseChannels(model)?.release);
+  }
   exposeAsGlobal("models", models);
 
   const dn = new Intl.DisplayNames("en", {
@@ -96,11 +127,17 @@ async function main() {
           lang: model.toLang,
           version: model.version,
           display: dn.of(model.toLang) ?? model.toLang,
-          toEn: [],
-          fromEn: [],
+          toEn: null,
+          fromEn: null,
         };
       }
-      entry.fromEn.push(model);
+      if (entry.fromEn) {
+        const message =
+          "Multiple models with the same version were found, this is an error that should be fixed in Remote Settings.";
+        alert(message);
+        console.error(message, entry.fromEn, model);
+      }
+      entry.fromEn = model;
     } else {
       entry = modelsMap.get(model.fromLang + " " + model.version);
       if (!entry) {
@@ -108,28 +145,33 @@ async function main() {
           lang: model.fromLang,
           version: model.version,
           display: dn.of(model.fromLang) ?? model.fromLang,
-          toEn: [],
-          fromEn: [],
+          toEn: null,
+          fromEn: null,
         };
       }
-      entry.toEn.push(model);
+      if (entry.toEn) {
+        const message =
+          "Multiple models with the same version were found, this is an error that should be fixed in Remote Settings.";
+        alert(message);
+        console.error(message, entry.toEn, model);
+      }
+
+      entry.toEn = model;
     }
     modelsMap.set(entry.lang + " " + model.version, entry);
   }
 
   const tbody = getElement("tbody");
 
-  const modelEntries = [...modelsMap.values()].sort((a, b) =>
-    `${a.lang}`.localeCompare(b.lang)
-  );
+  // Sort the models by language, and then version number.
+  const modelEntries = [...modelsMap.values()];
+  modelEntries.sort((a, b) => -versionCompare(a.version, b.version));
   modelEntries.sort((a, b) => a.display.localeCompare(b.display));
 
-  for (const entry of modelEntries) {
-    entry.fromEn.sort((a, b) => -versionCompare(a.version, b.version));
-    entry.toEn.sort((a, b) => -versionCompare(a.version, b.version));
-  }
+  // Only add the score once to a langpair.
+  const langPairScoreAdded = new Set();
 
-  for (const { lang, toEn, fromEn } of modelEntries) {
+  for (const { lang, version, toEn, fromEn } of modelEntries) {
     const tr = document.createElement("tr");
     /**
      * @param {string} [text]
@@ -141,6 +183,7 @@ async function main() {
       return el;
     };
     td(dn.of(lang));
+    td(version);
 
     addToRow(
       td,
@@ -148,7 +191,8 @@ async function main() {
       records.data,
       cometResults,
       attachmentsByKey,
-      toEn[0]
+      toEn,
+      langPairScoreAdded
     );
     addToRow(
       td,
@@ -156,7 +200,8 @@ async function main() {
       records.data,
       cometResults,
       attachmentsByKey,
-      fromEn[0]
+      fromEn,
+      langPairScoreAdded
     );
     tbody.append(tr);
   }
@@ -170,9 +215,25 @@ async function main() {
  * @param {ModelRecord[]} records
  * @param {EvalResults} cometResults
  * @param {Map<string, Array<[string, string]>>} attachmentsByKey
- * @param {ModelRecord} [model]
+ * @param {ModelRecord | null} model
+ * @param {Set<string>} langPairScoreAdded
  */
-function addToRow(td, pair, records, cometResults, attachmentsByKey, model) {
+function addToRow(
+  td,
+  pair,
+  records,
+  cometResults,
+  attachmentsByKey,
+  model,
+  langPairScoreAdded
+) {
+  if (!model) {
+    for (let i = 0; i < 4; i++) {
+      let el = td();
+      el.style.background = "#fff";
+    }
+    return;
+  }
   const modelNameTD = td();
   if (model) {
     // Add the attachments.
@@ -212,18 +273,31 @@ function addToRow(td, pair, records, cometResults, attachmentsByKey, model) {
     }
   }
 
-  td(model?.version);
   td(getModelSize(records, model));
 
-  const releaseEl = td(getReleaseChannel(model));
-  releaseEl.title = model?.filter_expression ?? "";
+  const releaseChannels = getReleaseChannels(model);
+  if (model) {
+    const releaseEl = td(releaseChannels?.label ?? "Custom");
+    releaseEl.title = model?.filter_expression ?? "";
+  } else {
+    td();
+  }
 
   const googleComet = cometResults[pair]?.["flores-test"]?.["google"];
   const bergamotComet = cometResults[pair]?.["flores-test"]?.["bergamot"];
   const googleCometAvg = getAverageScore(pair, cometResults, "google");
   const bergamotCometAvg = getAverageScore(pair, cometResults, "bergamot");
 
-  const hasEvals = bergamotComet && googleComet;
+  let hasEvals = Boolean(bergamotComet && googleComet);
+
+  // Only show the evals once for the latest model. We have no way to know which is
+  // the correct eval to show.
+  if (langPairScoreAdded.has(pair)) {
+    hasEvals = false;
+  }
+  if (hasEvals) {
+    langPairScoreAdded.add(pair);
+  }
 
   const bergamotCometDisplay = (100 * bergamotComet).toFixed(2);
   const percentage = 100 * (1 - googleComet / bergamotComet);
@@ -292,7 +366,7 @@ function getAverageScore(pair, cometResults, translator) {
 
 /**
  * @param {ModelRecord[]} records
- * @param {ModelRecord} [model]
+ * @param {ModelRecord | null} model
  */
 function getModelSize(records, model) {
   if (!model) {
@@ -382,45 +456,55 @@ export default function versionCompare(a, b) {
 }
 
 /**
- * @param {ModelRecord} [model]
- * @returns {string}
+ * @param {ModelRecord | null} model
+ * @returns {ReleaseInfo | null}
  */
-function getReleaseChannel(model) {
+function getReleaseChannels(model) {
   if (!model) {
-    return "";
-  }
-  let filterExpression = model.filter_expression ?? "";
-  filterExpression = filterExpression.replace(
-    "env.channel == 'default'",
-    "Local Build"
-  );
-  filterExpression = filterExpression.replace(
-    "env.channel == 'nightly'",
-    "Nightly"
-  );
-  filterExpression = filterExpression.replace("env.channel == 'beta'", "Beta");
-  filterExpression = filterExpression.replace(
-    "env.channel == 'release'",
-    "Release"
-  );
-  filterExpression = filterExpression.replace(
-    "env.channel == 'aurora'",
-    "Aurora"
-  );
-  filterExpression = filterExpression.replace("||", "or");
-  filterExpression = filterExpression.replace("&&", "and");
-  if (!filterExpression) {
-    return "Released";
-  }
-  if (model.version?.endsWith("a1")) {
-    filterExpression = "Local Build or Nightly";
+    return null;
   }
 
-  if (filterExpression === "Local Build or Nightly") {
-    // Simplify this to just nightly.
-    return "Nightly";
+  switch (model.filter_expression) {
+    case "env.channel == 'default' || env.channel == 'nightly' || env.channel == 'beta'":
+      return {
+        release: false,
+        beta: true,
+        nightly: true,
+        android: true,
+        label: "Beta",
+      };
+    case "env.appinfo.OS != 'Android' || env.channel != 'release'":
+      return {
+        release: false,
+        beta: true,
+        nightly: true,
+        android: false,
+        label: "Beta Desktop",
+      };
+    case "env.channel == 'default' || env.channel == 'nightly'":
+      return {
+        release: false,
+        beta: false,
+        nightly: true,
+        android: true,
+        label: "Nightly",
+      };
+    case "":
+    case undefined:
+      return {
+        release: true,
+        beta: true,
+        nightly: true,
+        android: true,
+        label: "Release",
+      };
+    default:
+      console.log(
+        "Come up with a label for this filter_expression:",
+        model.filter_expression
+      );
+      return null;
   }
-  return "Custom";
 }
 
 /**

--- a/site/firefox-models/models.mjs
+++ b/site/firefox-models/models.mjs
@@ -1,6 +1,10 @@
 // @ts-check
 import { changeLocation, exposeAsGlobal, getElement } from "../utils.mjs";
 
+/**
+ * @import { ModelRecord, EvalResults } from "../@types/models"
+ */
+
 main().catch((error) => {
   console.error(error);
   getElement("error").style.display = "block";
@@ -128,7 +132,7 @@ async function main() {
   for (const { lang, toEn, fromEn } of modelEntries) {
     const tr = document.createElement("tr");
     /**
-     * @param {string | HTML} [text]
+     * @param {string} [text]
      */
     const td = (text = "") => {
       const el = document.createElement("td");
@@ -212,7 +216,7 @@ function addToRow(td, pair, records, cometResults, attachmentsByKey, model) {
   td(getModelSize(records, model));
 
   const releaseEl = td(getReleaseChannel(model));
-  releaseEl.title = model?.filter_expression;
+  releaseEl.title = model?.filter_expression ?? "";
 
   const googleComet = cometResults[pair]?.["flores-test"]?.["google"];
   const bergamotComet = cometResults[pair]?.["flores-test"]?.["bergamot"];

--- a/site/model-registry/model-registry.mjs
+++ b/site/model-registry/model-registry.mjs
@@ -373,6 +373,7 @@ class ModelCardOverlay {
   /**
    * Reactively handle a state change to the model reference. This function is fast
    * enough to be called reactively, and only initializes the code when it is needed.
+   * @param {ModelReference | null} modelReference
    */
   static onStateChange(modelReference) {
     if (!modelReference) {
@@ -630,7 +631,8 @@ class ModelCardOverlay {
 
     for (const metric of ["chrf", "bleu", "comet"]) {
       const value = modelRun.flores
-        ? String(modelRun.flores[metric])
+        ? // @ts-ignore
+          String(modelRun.flores[metric])
         : "Not available";
       createMetricRow(metric, value);
     }
@@ -818,7 +820,7 @@ class ModelCardOverlay {
  * Fetches JSON data from a given URL.
  *
  * @param {string} url
- * @returns {Promise<Object>}
+ * @returns {Promise<any>}
  */
 async function fetchJSON(url) {
   const response = await fetch(url);
@@ -833,6 +835,7 @@ async function fetchJSON(url) {
  * @returns {Promise<TrainingRun[]>}
  */
 async function loadTrainingRuns() {
+  /** @type {TrainingRun[]} */
   const trainingRunListing = await fetchJSON(
     `${STORAGE_URL}/models/listing.json`
   );
@@ -878,6 +881,7 @@ class TrainingRunRow {
 
   /**
    * Construct the class with the required data.
+   * @param {TrainingRun} trainingRun
    */
   constructor(trainingRun) {
     this.trainingRun = trainingRun;

--- a/site/package.json
+++ b/site/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "translations-site",
+  "version": "0.0.0",
+  "type": "module",
+  "devDependencies": {
+    "typescript": "^5.8.3"
+  }
+}

--- a/site/tsconfig.json
+++ b/site/tsconfig.json
@@ -12,10 +12,9 @@
     "noEmit": true,
     // Allow esnext syntax. Otherwise the default is ES5 only.
     "target": "esnext",
-    "lib": ["esnext", "dom"],
+    "lib": ["esnext", "dom", "dom.iterable"],
     "esModuleInterop": true
   },
-  "include": ["./src/**/*.mjs", "./src/**/*.js"],
-  "files": ["src/@types/globals.d.ts"],
-  "exclude": []
+  "include": ["./**/*.mjs", "./**/*.js", "/**/*.ts"],
+  "exclude": ["./docs"]
 }

--- a/site/utils.mjs
+++ b/site/utils.mjs
@@ -1,7 +1,7 @@
 // @ts-check
 
 /**
- * @import { CreateElementOptions } from "./@types/globals"
+ * @import { CreateElementOptions } from "./@types/utils"
  */
 
 /**


### PR DESCRIPTION
The page is a bit buggy and broken for our models, so this cleans it up a bit so that it's easier to read, and correctly shows where things are released.

It defaults to released models now:

<img width="1358" alt="image" src="https://github.com/user-attachments/assets/a02be03f-18c2-47aa-952f-dc9d66194c29" />

Then when you view everything:

<img width="1443" alt="image" src="https://github.com/user-attachments/assets/5df6ed4c-4ccc-4051-a63d-41c95b42c932" />

Note that the first commit is getting TypeScript to pass. I haven't hooked all that up to CI yet, and checked it in pretty broken.