### PR TITLE
Add more details about the models to the Firefox Translations Models page

### DIFF
--- a/site/@types/models.d.ts
+++ b/site/@types/models.d.ts
@@ -55,3 +55,32 @@ export interface ReleaseInfo {
   android: boolean,
   label: string,
 }
+
+export interface ModelStatistics {
+    decoder_bytes: number,
+    decoder_parameters: number,
+    embeddings_bytes: number,
+    encoder_bytes: number,
+    encoder_parameters: number,
+    parameters: number,
+}
+
+
+export interface ModelMetadata {
+    // For instance "base-memory" or "tiny"
+    architecture: string,
+    // The size of the uncompressed model in bytes.
+    byteSize: number,
+    // The flores scores, e.g. { "bleu": 39.6, "comet": 0.8649 }
+    flores: Record<string, number>,
+    // The sha256 hash of the uncompressed model.
+    hash: string,
+    // The Marian config for the model.
+    modelConfig: Record<string, any>,
+    // The number of parameters and bytes for the model's size.
+    modelStatistics: ModelStatistics,
+    sourceLanguage: string,
+    targetLanguage: string,
+    // The version in Remote Settings, used to select the latest model.
+    version: string,
+}

--- a/site/firefox-models/index.html
+++ b/site/firefox-models/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+ <!DOCTYPE html>
 <html>
 <head>
   <meta charset="utf-8" />
@@ -36,6 +36,8 @@
     <div class="settings">
       <input type='checkbox' id="releasedModels" />
       <label for="releasedModels">Released Models Only</label><br/>
+      <input type='checkbox' id="showAdditionalDetails" />
+      <label for="showAdditionalDetails">Show Additional Details</label><br/>
       <input type='checkbox' id="remoteSettingsPreview" />
       <label for="remoteSettingsPreview">Use Remote Settings "Preview"</label>
     </div>
@@ -59,31 +61,44 @@
             <td id="fromNightly"></td>
             <td id="toNightly"></td>
           </tr>
+          <tr>
+            <th>Unique Languages</th>
+            <td id="uniqueLanguages" colspan="2"></td>
+          </tr>
         </tbody>
       </table>
 
-    <div class="table-container">
+    <div class="table-container models-container">
       <div class='noodles'>
         <img src="../assets/noodles2.png" class="noodles">
       </div>
       <div class='table-overflow'>
         <table class="models" id="table">
           <thead>
-            <tr>
+            <tr id="topRow">
               <th>Language</th>
-              <th>Version</th>
-              <th>Model</th>
-              <th>Size</th>
-              <th>Release</th>
-              <th title="The model must be within 5% COMET evaluation score of Google's models to be shippable">
+
+              <th class="modelColumn">Model</th>
+              <th class="versionColumn" title="Version">Ver.</th>
+              <th class="sizeColumn">Size</th>
+              <th class="releaseColumn">Release</th>
+              <th class="scoreColumn"
+                  title="The model must be within 5% COMET evaluation score of Google's models to be shippable">
                 Score
               </th>
-              <th>Model</th>
-              <th>Size</th>
-              <th>Release</th>
-              <th title="The model must be within 5% COMET evaluation score of Google's models to be shippable">
+              <th class="architectureColumn">Architecture</th>
+              <th class="parametersColumn">Parameters</th>
+
+              <th class="modelColumn columnSeparator">Model</th>
+              <th class="versionColumn">Ver.</th>
+              <th class="sizeColumn">Size</th>
+              <th class="releaseColumn">Release</th>
+              <th class="scoreColumn"
+              title="The model must be within 5% COMET evaluation score of Google's models to be shippable">
                 Score
               </th>
+              <th class="architectureColumn">Architecture</th>
+              <th class="parametersColumn">Parameters</th>
             </tr>
           </thead>
           <tbody id="tbody">

--- a/site/firefox-models/models.css
+++ b/site/firefox-models/models.css
@@ -29,6 +29,12 @@
   margin: 10px 0 30px;
 }
 
+body:not(.showAdditionalDetails) {
+  :is(.sizeColumn, .architectureColumn, .parametersColumn, .versionColumn) {
+    display: none;
+  }
+}
+
 .models {
   margin: 1rem;
 
@@ -38,34 +44,32 @@
 
   /* Language Name */
   & :is(th, td):nth-child(1) {
-    font-weight: bold;
-    padding-right: 0;
-  }
-
-  /* Version Name */
-  & :is(th, td):nth-child(2) {
     border-right: 2px solid #aaa;
-    text-align: right;
-    padding-left: 0;
+    font-weight: bold;
   }
 
-  & :is(th, td):nth-child(7) {
+  & :is(th, td):nth-child(9) {
     border-left: 2px solid #aaa;
   }
 
+  /* Version Name */
+  td.versionColumn {
+    text-align: right;
+  }
+
   /* models */
-  & td:is(:nth-child(3), :nth-child(7)) {
+  td.modelColumn {
     background-color: #0001;
     font-family: monospace;
   }
 
   /* Size */
-  & :is(td):is(:nth-child(4), :nth-child(8)) {
+  td.sizeColumn {
     text-align: right;
   }
 
   /* Scores */
-  & td:is(:nth-child(6), :nth-child(11)) {
+  td.scoreColumn {
     font-family: monospace;
     text-align: right;
   }
@@ -87,4 +91,21 @@
       }
     }
   }
+}
+
+.empty {
+  background: linear-gradient(#c7c9cf, #e2e2e2 46%);
+  border: #00000045 1px solid;
+  border-left: none;
+  border-right: none;
+}
+
+.models-container {
+  margin-bottom: 4em;
+}
+
+.metadataPre {
+  background: #eee;
+  padding: 15px;
+  border-radius: 7px;
 }

--- a/site/utils.mjs
+++ b/site/utils.mjs
@@ -15,6 +15,15 @@ export function asAny(any) {
 /**
  * @param {URLSearchParams} urlParams
  */
+export function replaceLocation(urlParams) {
+  const url = new URL(window.location.href);
+  const newLocation = `${url.origin}${url.pathname}?${urlParams}`;
+  history.replaceState(null, "", newLocation);
+}
+
+/**
+ * @param {URLSearchParams} urlParams
+ */
 export function changeLocation(urlParams) {
   const url = new URL(window.location.href);
   const newLocation = `${url.origin}${url.pathname}?${urlParams}`;


### PR DESCRIPTION
After https://github.com/mozilla/firefox-translations-models/pull/240 merges this will look up the models by hash to display information about the model, including COMET scores. The COMET scores are currently broken with the refactor in the other repo of the model layouts.

<img width="1717" alt="image" src="https://github.com/user-attachments/assets/e00c627d-1e47-4771-958f-7e199ca5f49f" />

I also created a "product manager" mode, which is the default view of this page so you can easily see what is released without all of the nitty gritty details of model architectures and versioning.

<img width="1406" alt="image" src="https://github.com/user-attachments/assets/1b251843-a2dc-486c-a076-339c8a67885e" />

The last commit needs to be removed before merging, it's pointing to a temporary branch so this all works before https://github.com/mozilla/firefox-translations-models/pull/240 merges.