### PR TITLE
Always specify the best and first number for shortlists 

### DIFF
--- a/pipeline/eval/eval.py
+++ b/pipeline/eval/eval.py
@@ -187,12 +187,20 @@ def main(args_list: Optional[list[str]] = None) -> None:
         marian_extra_args = [*marian_extra_args, "--vocabs", args.vocab_src, args.vocab_trg]
 
     if args.shortlist:
-        # No arguments to the shortlist, so default ones are used
-        # this way it doesn't matter if the shortlist is binary or text
-        # because they have different arguments
-        # text shortlist args: firstNum bestNum threshold
-        # binary shortlist (has the arguments embedded) args: bool (check integrity)
-        marian_extra_args = marian_extra_args + ["--shortlist", args.shortlist]
+        # Marian has different behaviors for the CLI based on whether a shortlist is
+        # the binary format, which has the hyper parameters embedded within it, and
+        # whether or not it is a text one, which must have the hyperparameters provided.
+        # Just be explicit here with hard coded values.
+        marian_extra_args = marian_extra_args + [
+            "--shortlist",
+            args.shortlist,
+            # first number
+            "50",
+            # best number
+            "50",
+            # threshold
+            "0",
+        ]
 
     logger.info("The eval script is configured with the following:")
     logger.info(f" >          artifacts_dir: {artifacts_dir}")

--- a/pipeline/quantize/quantize.sh
+++ b/pipeline/quantize/quantize.sh
@@ -35,7 +35,7 @@ test -s "${output_dir}/quantmults" ||
     --config "decoder.yml" \
     --input "${devtest_src}" \
     --output "${output_dir}/output.${TRG}" \
-    --shortlist "${shortlist}" false \
+    --shortlist "${shortlist}" 50 50 0 \
     --quiet \
     --quiet-translation \
     --log "${output_dir}/cpu.output.log" \

--- a/taskcluster/kinds/evaluate-quantized/kind.yml
+++ b/taskcluster/kinds/evaluate-quantized/kind.yml
@@ -111,7 +111,6 @@ tasks:
                     --dataset_prefix    "$MOZ_FETCHES_DIR/{dataset_sanitized}"
                     --vocab_src          "$MOZ_FETCHES_DIR/vocab.{src_locale}.spm"
                     --vocab_trg          "$MOZ_FETCHES_DIR/vocab.{trg_locale}.spm"
-                    --shortlist         "$MOZ_FETCHES_DIR/lex.s2t.pruned"
                     --artifacts_prefix  "$TASK_WORKDIR/artifacts/{dataset_sanitized}"
                     --marian_config     "$VCS_PATH/pipeline/quantize/decoder.yml"
                     --marian            "$BMT_MARIAN"

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -37,7 +37,6 @@ def get_quantized_marian_args(data_dir: DataDir, model_name: str):
         "--log", data_dir.join("artifacts/wmt09.log"),
         '--int8shiftAlphaAll',
         '--vocabs', data_dir.join("vocab.en.spm"), data_dir.join("vocab.ru.spm"),
-        '--shortlist', data_dir.join("lex.s2t.pruned"),
     ]  # fmt: skip
 
 


### PR DESCRIPTION
I read through Marian's source code to see what was going on with shortlisting, and there are two behaviors based on whether the format is binary or text. I changed our code to just be explicit on providing our hyper parameters as hard coded values so that things won't get screwed up.

I also disabled shortlisting in the eval since we aren't using it in production right now.