### PR TITLE
Add continuation parameters to the vocab cache

### DIFF
--- a/taskcluster/kinds/build-vocab/kind.yml
+++ b/taskcluster/kinds/build-vocab/kind.yml
@@ -36,6 +36,8 @@ tasks:
                     spm_sample_size: training_config.experiment.spm-sample-size
                     spm_vocab_size: training_config.experiment.spm-vocab-size
                     spm_vocab_split: training_config.experiment.spm-vocab-split
+                    continuation_src: training_config.continuation.vocab.src
+                    continuation_trg: training_config.continuation.vocab.trg
         task-context:
             from-parameters:
                 spm_sample_size: training_config.experiment.spm-sample-size


### PR DESCRIPTION
This was a bug I fixed from the continuation code, where I forgot to add these parameters in.