### PR TITLE
fix: handle multidigit chunks correctly in upload artifacts transform

### DIFF
--- a/taskcluster/translations_taskgraph/transforms/upload_artifacts.py
+++ b/taskcluster/translations_taskgraph/transforms/upload_artifacts.py
@@ -161,7 +161,7 @@ def task_to_step_dir(task_label: str) -> str:
     )
 
 
-CHUNKED_TASK_PATTERN = re.compile(".*([0-9]+)/([0-9]+)$")
+CHUNKED_TASK_PATTERN = re.compile("[^0-9]*([0-9]+)/([0-9]+)$")
 
 
 def get_chunk_number(task_label: str) -> str:


### PR DESCRIPTION
The current regex only takes the last digit of the chunk number.