### PR TITLE
Fix wandb attribute annotation for upcoming wandb releases

### DIFF
--- a/tracking/translations_parser/publishers.py
+++ b/tracking/translations_parser/publishers.py
@@ -114,7 +114,7 @@ class WandB(Publisher):
         self.artifacts_name = artifacts_name
         self.extra_kwargs = extra_kwargs
         self.parser: TrainingParser | None = None
-        self.wandb: wandb.sdk.wandb_run.Run | wandb.sdk.lib.disabled.RunDisabled | None = None
+        self.wandb: wandb.sdk.wandb_run.Run | None = None
 
     def close(self) -> None:
         if self.wandb is None:


### PR DESCRIPTION
wandb deprecated `RunDisabled` in v0.17.6 (wandb/wandb#8064): since then, `wandb.init(mode="disabled")` returns a regular no-op `wandb.Run`, and `RunDisabled` has been an empty compatibility shim that emits a deprecation warning on attribute access. The shim is being removed in an upcoming wandb release (wandb/wandb#12586), after which importing it raises `ImportError`.

This PR drops the remaining references so the integration keeps working with upcoming wandb releases, while remaining compatible with older ones.

Details: `WandB.__init__` annotates `self.wandb: wandb.sdk.wandb_run.Run | wandb.sdk.lib.disabled.RunDisabled | None`. Attribute-target annotations are evaluated at runtime (this module does not use `from __future__ import annotations`), so once wandb removes the class, constructing the publisher raises `AttributeError`. The annotation is narrowed to `Run | None`; behavior is unchanged.
