### PR TITLE
Use released models for pivot evaluations

### DIFF
--- a/pipeline/eval/translators.py
+++ b/pipeline/eval/translators.py
@@ -316,6 +316,10 @@ class BergamotModel:
 class BergamotTranslator(Translator):
     name = "bergamot"
     cached_models = None  # type: dict[tuple[str,str], list[BergamotModel]] | None
+    release_models_url = (
+        "https://firefox.settings.services.mozilla.com/v1/buckets/main/"
+        "collections/translations-models-v2/records"
+    )
 
     def __init__(self, src: str, trg: str, bucket: str, translator_cli_path: str):
         super().__init__(src, trg)
@@ -372,6 +376,41 @@ class BergamotTranslator(Translator):
         ]
 
         return [m.name for m in latest_models]
+
+    def list_release_models(self) -> list[str]:
+        """List models deployed to the unfiltered Firefox release channel."""
+        try:
+            response = requests.get(self.release_models_url)
+            response.raise_for_status()
+            release_hashes = {
+                record["decompressedHash"]
+                for record in response.json().get("data", [])
+                if record.get("sourceLanguage") == self.src
+                and record.get("targetLanguage") == self.trg
+                and record.get("fileType") == "model"
+                and record.get("filter_expression", "") == ""
+                and record.get("decompressedHash")
+            }
+        except (requests.RequestException, ValueError):
+            return []
+
+        release_models = []
+        for model in self.list_all_models(self.bucket, src=self.src, trg=self.trg):
+            metadata_url = (
+                f"https://storage.googleapis.com/{self.bucket}/models/"
+                f"{self.src}-{self.trg}/{model.name}/exported/metadata.json"
+            )
+            try:
+                metadata_response = requests.get(metadata_url)
+                metadata_response.raise_for_status()
+                model_hash = metadata_response.json().get("hash")
+            except (requests.RequestException, ValueError):
+                continue
+            if model_hash in release_hashes:
+                release_models.append(model)
+
+        release_models.sort(key=lambda model: model.last_update, reverse=True)
+        return [model.name for model in release_models]
 
     def prepare(self, model_name: str):
         shortlist = f"lex.50.50.{self.src}{self.trg}.s2t.bin.gz"
@@ -455,10 +494,17 @@ class BergamotPivotTranslator(BergamotTranslator):
         self.en_trg_translator = BergamotTranslator("en", trg, bucket, translator_cli_path)
 
     def list_models(self) -> list[str]:
-        # pick only the latest models and form a joint model name
+        # Prefer the models deployed in Firefox. Fall back to the latest models
+        # when a language direction does not have a release-channel model.
         # we do not want to evaluate all possible combinations of existing models
-        src_en_models = self.src_en_translator.list_latest_models()
-        en_trg_models = self.en_trg_translator.list_latest_models()
+        src_en_models = (
+            self.src_en_translator.list_release_models()
+            or self.src_en_translator.list_latest_models()
+        )
+        en_trg_models = (
+            self.en_trg_translator.list_release_models()
+            or self.en_trg_translator.list_latest_models()
+        )
 
         if not src_en_models or not en_trg_models:
             return []

--- a/pipeline/eval/translators.py
+++ b/pipeline/eval/translators.py
@@ -8,17 +8,23 @@ from abc import ABC
 from collections import defaultdict
 from dataclasses import dataclass
 from datetime import datetime
-from itertools import groupby
+from itertools import groupby, islice
 from pathlib import Path
 from typing import Any
 
 import requests
-import toolz
 import yaml
 from tqdm import tqdm
 
 from pipeline.common.downloads import location_exists
 from pipeline.langs.codes import LangCode
+
+
+def partition_all(size: int, values):
+    """Yield nonempty tuples of at most ``size`` values."""
+    iterator = iter(values)
+    while batch := tuple(islice(iterator, size)):
+        yield batch
 
 
 class LanguagePairNotSupported(Exception):
@@ -95,7 +101,7 @@ class GoogleTranslator(Translator):
 
         results = []
         # decrease partition size if hitting limit of max 204800 bytes per request
-        for partition in tqdm(list(toolz.partition_all(20, texts))):
+        for partition in tqdm(list(partition_all(20, texts))):
             for _ in range(7):
                 response = do_translate(partition)
                 if response is not None:
@@ -135,7 +141,7 @@ class MicrosoftTranslator(Translator):
 
         results = []
         # decrease partition size if hitting limit of max 10000 characters per request
-        for partition in tqdm(list(toolz.partition_all(20, texts))):
+        for partition in tqdm(list(partition_all(20, texts))):
             body = [{"text": text} for text in partition]
 
             response = None
@@ -193,7 +199,7 @@ class NllbTranslator(Translator):
     def translate(self, texts: list[str]) -> list[str]:
         results = []
 
-        for partition in tqdm(list(toolz.partition_all(10, texts))):
+        for partition in tqdm(list(partition_all(10, texts))):
             tokenized_src = self.tokenizer(partition, return_tensors="pt", padding=True).to(
                 self.device
             )
@@ -233,7 +239,7 @@ class OpusmtTranslator(Translator):
     def translate(self, texts: list[str]) -> list[str]:
         results = []
 
-        for partition in tqdm(list(toolz.partition_all(10, texts))):
+        for partition in tqdm(list(partition_all(10, texts))):
             tokenized_src = self.tokenizer(partition, return_tensors="pt", padding=True).to(
                 self.device
             )

--- a/taskcluster/configs/eval.all.yml
+++ b/taskcluster/configs/eval.all.yml
@@ -38,7 +38,9 @@ evals:
     - llm-ref
 
   # Bergamot models (it should match model name on GCS)
-  # For non-English centric pairs like it-de, provide two model IDs for both xx-en and en-xx
+  # Non-English centric pairs like it-de use the released xx-en and en-xx models,
+  # falling back to the latest uploaded model when a direction has no release.
+  # To override that selection, provide two model IDs for both xx-en and en-xx.
   # Use "models: ["latest"]" to run only for the last updated model per language pair
   # Leave empty to automatically discover all Bergamot models on GCS
   models: []

--- a/tests/test_final_eval_translators.py
+++ b/tests/test_final_eval_translators.py
@@ -17,10 +17,14 @@ def test_pivot_prefers_release_models(monkeypatch):
     }
     hashes = {"released-de-en": "hash-de-en", "released-en-fr": "hash-en-fr"}
 
+    def list_models(_bucket: str, src: str | None = None, trg: str | None = None):
+        assert src is not None and trg is not None
+        return models[(src, trg)]
+
     monkeypatch.setattr(
         BergamotTranslator,
         "list_all_models",
-        staticmethod(lambda _bucket, src=None, trg=None: models[(src, trg)]),
+        staticmethod(list_models),
     )
 
     class Response:
@@ -78,10 +82,15 @@ def test_pivot_falls_back_to_latest_model_without_release(monkeypatch):
         ("de", "en"): [BergamotModel("de", "en", "latest-de-en", now)],
         ("en", "fr"): [BergamotModel("en", "fr", "latest-en-fr", now)],
     }
+
+    def list_models(_bucket: str, src: str | None = None, trg: str | None = None):
+        assert src is not None and trg is not None
+        return models[(src, trg)]
+
     monkeypatch.setattr(
         BergamotTranslator,
         "list_all_models",
-        staticmethod(lambda _bucket, src=None, trg=None: models[(src, trg)]),
+        staticmethod(list_models),
     )
     monkeypatch.setattr(BergamotTranslator, "list_release_models", lambda _self: [])
 

--- a/tests/test_final_eval_translators.py
+++ b/tests/test_final_eval_translators.py
@@ -1,0 +1,90 @@
+from datetime import datetime, timedelta
+
+from pipeline.eval.translators import BergamotModel, BergamotPivotTranslator, BergamotTranslator
+
+
+def test_pivot_prefers_release_models(monkeypatch):
+    now = datetime.now()
+    models = {
+        ("de", "en"): [
+            BergamotModel("de", "en", "released-de-en", now),
+            BergamotModel("de", "en", "newer-de-en", now + timedelta(days=1)),
+        ],
+        ("en", "fr"): [
+            BergamotModel("en", "fr", "released-en-fr", now),
+            BergamotModel("en", "fr", "newer-en-fr", now + timedelta(days=1)),
+        ],
+    }
+    hashes = {"released-de-en": "hash-de-en", "released-en-fr": "hash-en-fr"}
+
+    monkeypatch.setattr(
+        BergamotTranslator,
+        "list_all_models",
+        staticmethod(lambda _bucket, src=None, trg=None: models[(src, trg)]),
+    )
+
+    class Response:
+        def __init__(self, data):
+            self.data = data
+
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return self.data
+
+    def get(url):
+        if url == BergamotTranslator.release_models_url:
+            return Response(
+                {
+                    "data": [
+                        {
+                            "sourceLanguage": "de",
+                            "targetLanguage": "en",
+                            "fileType": "model",
+                            "filter_expression": "",
+                            "decompressedHash": "hash-de-en",
+                        },
+                        {
+                            "sourceLanguage": "en",
+                            "targetLanguage": "fr",
+                            "fileType": "model",
+                            "filter_expression": "",
+                            "decompressedHash": "hash-en-fr",
+                        },
+                        {
+                            "sourceLanguage": "de",
+                            "targetLanguage": "en",
+                            "fileType": "model",
+                            "filter_expression": "env.channel == 'nightly'",
+                            "decompressedHash": "hash-newer-de-en",
+                        },
+                    ]
+                }
+            )
+        name = url.split("/")[-3]
+        return Response({"hash": hashes.get(name, f"hash-{name}")})
+
+    monkeypatch.setattr("pipeline.eval.translators.requests.get", get)
+
+    translator = BergamotPivotTranslator("de", "fr", "bucket", "bergamot-translator")
+
+    assert translator.list_models() == ["released-de-en---released-en-fr"]
+
+
+def test_pivot_falls_back_to_latest_model_without_release(monkeypatch):
+    now = datetime.now()
+    models = {
+        ("de", "en"): [BergamotModel("de", "en", "latest-de-en", now)],
+        ("en", "fr"): [BergamotModel("en", "fr", "latest-en-fr", now)],
+    }
+    monkeypatch.setattr(
+        BergamotTranslator,
+        "list_all_models",
+        staticmethod(lambda _bucket, src=None, trg=None: models[(src, trg)]),
+    )
+    monkeypatch.setattr(BergamotTranslator, "list_release_models", lambda _self: [])
+
+    translator = BergamotPivotTranslator("de", "fr", "bucket", "bergamot-translator")
+
+    assert translator.list_models() == ["latest-de-en---latest-en-fr"]


### PR DESCRIPTION
Fixes #1330.

Pivot evaluations now select each leg's production release-channel model from Remote Settings, falling back to the latest upload when no release match exists.

Tests cover release selection, Nightly exclusion, and fallback behavior.
